### PR TITLE
style(tables): auto-fit intensive-margin tables to \linewidth

### DIFF
--- a/scripts/R/09_analysis/02_hedonic/hedonic_continuous_prior.R
+++ b/scripts/R/09_analysis/02_hedonic/hedonic_continuous_prior.R
@@ -437,7 +437,7 @@ run_for_radius <- function(RAD) {
   # Add colsep and font size for tighter column spacing
   table_latex_count <- sub(
     "(\\{\\s*%% tabularray inner open\\n)",
-    "\\1colsep=3pt,\ncells   = {font = \\\\fontsize{11pt}{12pt}\\\\selectfont},\n",
+    "\\1colsep=2pt,\ncells   = {font = \\\\fontsize{8pt}{9pt}\\\\selectfont},\n",
     table_latex_count
   )
 
@@ -447,6 +447,11 @@ run_for_radius <- function(RAD) {
     custom_notes_count,
     table_latex_count
   )
+
+  # Distribute available width among columns (X[] instead of Q[]) so the table
+  # auto-fits \linewidth (first column stays natural-width label)
+  table_latex_count <- gsub("Q\\[\\]", "X[c] ", table_latex_count)
+  table_latex_count <- sub("colspec=\\{X\\[c\\] ", "colspec={l ", table_latex_count)
 
   output_path_count <- file.path(output_dir, paste0("hedonic_count_continuous_prior_", RAD, "m.tex"))
   writeLines(table_latex_count, output_path_count)
@@ -515,7 +520,7 @@ run_for_radius <- function(RAD) {
   # Add colsep and font size for tighter column spacing
   table_latex_hrs <- sub(
     "(\\{\\s*%% tabularray inner open\\n)",
-    "\\1colsep=3pt,\ncells   = {font = \\\\fontsize{11pt}{12pt}\\\\selectfont},\n",
+    "\\1colsep=2pt,\ncells   = {font = \\\\fontsize{8pt}{9pt}\\\\selectfont},\n",
     table_latex_hrs
   )
 
@@ -525,6 +530,11 @@ run_for_radius <- function(RAD) {
     custom_notes_hrs,
     table_latex_hrs
   )
+
+  # Distribute available width among columns (X[] instead of Q[]) so the table
+  # auto-fits \linewidth (first column stays natural-width label)
+  table_latex_hrs <- gsub("Q\\[\\]", "X[c] ", table_latex_hrs)
+  table_latex_hrs <- sub("colspec=\\{X\\[c\\] ", "colspec={l ", table_latex_hrs)
 
   output_path_hrs <- file.path(output_dir, paste0("hedonic_hrs_continuous_prior_", RAD, "m.tex"))
   writeLines(table_latex_hrs, output_path_hrs)

--- a/scripts/R/09_analysis/02_hedonic/hedonic_continuous_prior_qtr_fe.R
+++ b/scripts/R/09_analysis/02_hedonic/hedonic_continuous_prior_qtr_fe.R
@@ -444,7 +444,7 @@ run_for_radius <- function(RAD) {
   # Add colsep and font size for tighter column spacing
   table_latex_count <- sub(
     "(\\{\\s*%% tabularray inner open\\n)",
-    "\\1colsep=3pt,\ncells   = {font = \\\\fontsize{11pt}{12pt}\\\\selectfont},\n",
+    "\\1colsep=2pt,\ncells   = {font = \\\\fontsize{8pt}{9pt}\\\\selectfont},\n",
     table_latex_count
   )
 
@@ -454,6 +454,11 @@ run_for_radius <- function(RAD) {
     custom_notes_count,
     table_latex_count
   )
+
+  # Distribute available width among columns (X[] instead of Q[]) so the table
+  # auto-fits \linewidth (first column stays natural-width label)
+  table_latex_count <- gsub("Q\\[\\]", "X[c] ", table_latex_count)
+  table_latex_count <- sub("colspec=\\{X\\[c\\] ", "colspec={l ", table_latex_count)
 
   output_path_count <- file.path(output_dir, paste0("hedonic_count_continuous_prior_qtr_fe_", RAD, "m.tex"))
   writeLines(table_latex_count, output_path_count)
@@ -522,7 +527,7 @@ run_for_radius <- function(RAD) {
   # Add colsep and font size for tighter column spacing
   table_latex_hrs <- sub(
     "(\\{\\s*%% tabularray inner open\\n)",
-    "\\1colsep=3pt,\ncells   = {font = \\\\fontsize{11pt}{12pt}\\\\selectfont},\n",
+    "\\1colsep=2pt,\ncells   = {font = \\\\fontsize{8pt}{9pt}\\\\selectfont},\n",
     table_latex_hrs
   )
 
@@ -532,6 +537,11 @@ run_for_radius <- function(RAD) {
     custom_notes_hrs,
     table_latex_hrs
   )
+
+  # Distribute available width among columns (X[] instead of Q[]) so the table
+  # auto-fits \linewidth (first column stays natural-width label)
+  table_latex_hrs <- gsub("Q\\[\\]", "X[c] ", table_latex_hrs)
+  table_latex_hrs <- sub("colspec=\\{X\\[c\\] ", "colspec={l ", table_latex_hrs)
 
   output_path_hrs <- file.path(output_dir, paste0("hedonic_hrs_continuous_prior_qtr_fe_", RAD, "m.tex"))
   writeLines(table_latex_hrs, output_path_hrs)

--- a/scripts/R/09_analysis/05_news/did_articles_prior.R
+++ b/scripts/R/09_analysis/05_news/did_articles_prior.R
@@ -457,7 +457,7 @@ run_for_radius <- function(RAD) {
   # Add colsep and font size for tighter column spacing
   table_latex <- sub(
     "(\\{\\s*%% tabularray inner open\\n)",
-    "\\1colsep=3pt,\ncells   = {font = \\\\fontsize{11pt}{12pt}\\\\selectfont},\n",
+    "\\1colsep=2pt,\ncells   = {font = \\\\fontsize{8pt}{9pt}\\\\selectfont},\n",
     table_latex
   )
 

--- a/scripts/R/09_analysis/05_news/did_trends_prior.R
+++ b/scripts/R/09_analysis/05_news/did_trends_prior.R
@@ -432,7 +432,7 @@ run_for_radius <- function(RAD) {
   # Add colsep and font size for tighter column spacing
   table_latex <- sub(
     "(\\{\\s*%% tabularray inner open\\n)",
-    "\\1colsep=3pt,\ncells   = {font = \\\\fontsize{11pt}{12pt}\\\\selectfont},\n",
+    "\\1colsep=2pt,\ncells   = {font = \\\\fontsize{8pt}{9pt}\\\\selectfont},\n",
     table_latex
   )
 


### PR DESCRIPTION
## What
Make the four intensive-margin table scripts emit tables that auto-fit the text width:
- Convert the hedonic tables' `Q[]` columns to `X[c]` (the label column stays `l`), so the table fills `\linewidth`. The two news scripts (`did_trends_prior`, `did_articles_prior`) already did this.
- Set `colsep=2pt` and font `\fontsize{8pt}{9pt}` across all four scripts.

## Why
The 13-column regression tables used natural-width `Q[]` columns and overflowed the page margin, needing manual font tweaks to fit. `X[c]` columns force the table to `\linewidth`, so it can no longer overflow horizontally regardless of font size.

## Scope
- Formatting only — no change to specifications, estimates, samples, or data.
- Files: `02_hedonic/hedonic_continuous_prior.R`, `02_hedonic/hedonic_continuous_prior_qtr_fe.R`, `05_news/did_trends_prior.R`, `05_news/did_articles_prior.R`.