### PR TITLE
docs(cross-section): standardise study-period headers

### DIFF
--- a/scripts/R/06_analysis_datasets/cross_section_rental.R
+++ b/scripts/R/06_analysis_datasets/cross_section_rental.R
@@ -1,6 +1,25 @@
 # ==============================================================================
 # Study-Period Rental Cross-Section Builder
 # ==============================================================================
+#
+# Purpose: Build and publish the 2021-2024 spill-exposure cross-section for
+#          rental listings at transaction-radius grain through the shared
+#          study-period engine.
+#
+# Author: Jacopo Olivieri
+# Date: 2025-04-05
+# Date Modified: 2026-08-14
+#
+# Inputs:
+#   - data/processed/zoopla/zoopla_rentals.parquet
+#   - data/processed/zoopla/spill_rental_lookup.parquet
+#   - data/processed/matched_events_annual_data/site_group_crosswalk.parquet
+#
+# Outputs:
+#   - data/processed/cross_section/rentals/study_period/
+#   - output/log/cross_section_rental.log
+#
+# ==============================================================================
 
 if (!requireNamespace("here", quietly = TRUE)) {
   stop(

--- a/scripts/R/06_analysis_datasets/cross_section_rental.R
+++ b/scripts/R/06_analysis_datasets/cross_section_rental.R
@@ -2,9 +2,9 @@
 # Study-Period Rental Cross-Section Builder
 # ==============================================================================
 #
-# Purpose: Build and publish the 2021-2024 spill-exposure cross-section for
-#          rental listings at transaction-radius grain through the shared
-#          study-period engine.
+# Purpose: Build the rental cross-section at the rental listing level. For each
+#          rental listing and radius, sum spill counts and hours across all sites
+#          within that radius over the full 2021–2024 study period.
 #
 # Author: Jacopo Olivieri
 # Date: 2025-04-05

--- a/scripts/R/06_analysis_datasets/cross_section_sales.R
+++ b/scripts/R/06_analysis_datasets/cross_section_sales.R
@@ -1,6 +1,25 @@
 # ==============================================================================
 # Study-Period Sales Cross-Section Builder
 # ==============================================================================
+#
+# Purpose: Build and publish the 2021-2024 spill-exposure cross-section for
+#          property sales at transaction-radius grain through the shared
+#          study-period engine.
+#
+# Author: Jacopo Olivieri
+# Date: 2025-04-05
+# Date Modified: 2026-08-14
+#
+# Inputs:
+#   - data/processed/house_price.parquet
+#   - data/processed/spill_house_lookup.parquet
+#   - data/processed/matched_events_annual_data/site_group_crosswalk.parquet
+#
+# Outputs:
+#   - data/processed/cross_section/sales/study_period/
+#   - output/log/cross_section_sales.log
+#
+# ==============================================================================
 
 if (!requireNamespace("here", quietly = TRUE)) {
   stop(

--- a/scripts/R/06_analysis_datasets/cross_section_sales.R
+++ b/scripts/R/06_analysis_datasets/cross_section_sales.R
@@ -2,9 +2,10 @@
 # Study-Period Sales Cross-Section Builder
 # ==============================================================================
 #
-# Purpose: Build and publish the 2021-2024 spill-exposure cross-section for
-#          property sales at transaction-radius grain through the shared
-#          study-period engine.
+# Purpose: Build the sales cross-section at the property-transaction level. For
+#          each property transaction and radius, sum spill counts and hours
+#          across all sites within that radius over the full 2021–2024 study
+#          period.
 #
 # Author: Jacopo Olivieri
 # Date: 2025-04-05


### PR DESCRIPTION
Completes the documentation follow-up to #29: both study-period entrypoints now expose the standard purpose, provenance, input, output, and log metadata without changing runtime behavior.

Validated by parsing both scripts under R 4.6.0 and running the U1-U5 contract suite.
