### PR TITLE
Rebuild transaction identity and repeat-transaction mappings on content-stable hashes

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -74,6 +74,26 @@ The effect of sewage-spill *intensity* — a continuous exposure measure such as
 ### Extensive Margin
 The effect of *proximity itself* — being near versus far from an overflow — on property values, and how the near-versus-far price gap responds to public attention. Contrasts with the Intensive Margin, which varies realized spill intensity rather than proximity.
 
+## Repeat-Transactions Area
+
+### Content-Stable Transaction ID
+The identity of one cleaned sale or rental transaction, derived from the transaction's own recorded values rather than from its position in the file. Regenerating an input cannot silently re-label transactions: identifiers across artifact generations either match exactly or fail loudly.
+
+### Address Key
+The normalised composite of postcode and address components that identifies one property unit for repeat matching. A transaction missing its postcode or its primary address component carries no Address Key and cannot participate in repeat identification.
+
+### Keyable Transaction
+A transaction that carries an Address Key. Only keyable transactions can be assigned to a Repeat Group.
+
+### Repeat Group
+All Keyable Transactions in one dataset that share an Address Key — the project's operational notion of "the same property transacting repeatedly". A group of size one is a single; singles still belong to a Repeat Group. Group identity derives from the Address Key itself, so it is stable across runs; distinct Address Keys are asserted to map to distinct group identifiers at build time, and a group identifier is meaningful only within its own market's mapping.
+
+### Repeat-Transactions Mapping
+The transaction-grain artifact assigning every Keyable Transaction to its Repeat Group, singles included, with the group size recorded. It is a census of keyable transactions — exclusions are auditable by subtraction — and the sole bridge between cleaned transactions and repeat-based analyses. Group membership and group size are defined over the Long-Run Transaction History; a consumer restricting to a narrower window must regroup rather than trust the recorded size.
+
+### Long-Run Transaction History
+The maximal retained span of cleaned transactions (from 2014, the earliest rental coverage), wider than the spill study window. Repeat identification runs over the long-run history; the study-window transaction tables are derived from it by filtering, never built independently, so both views agree row-for-row where they overlap.
+
 ## Public Attention Area
 
 ### Public Attention

--- a/book/event_study.qmd
+++ b/book/event_study.qmd
@@ -408,7 +408,6 @@ spill_qtr <- import(path_spill, trust = TRUE) %>%
 house_controls <- open_dataset(path_house_controls) %>%
   collect() %>%
   select(
-    -transaction_id,
     -price,
     -date_of_transfer,
     -postcode,
@@ -1645,7 +1644,6 @@ spill_qtr <- import(path_spill, trust = TRUE) %>%
 house_controls <- open_dataset(path_house_controls) %>%
   collect() %>%
   select(
-    -transaction_id,
     -date_of_transfer,
     -postcode,
     -saon,

--- a/book/hedonic_regs.qmd
+++ b/book/hedonic_regs.qmd
@@ -96,7 +96,6 @@ spill_qtr <- import(path_spill, trust = TRUE) %>%
 house_controls <- open_dataset(path_house_controls) %>%
   collect() %>%
   select(
-    -transaction_id,
     -date_of_transfer,
     -postcode,
     -saon,
@@ -825,4 +824,3 @@ modelsummary(
 :::
 
 :::
-

--- a/book/house_data_exploration.qmd
+++ b/book/house_data_exploration.qmd
@@ -134,11 +134,11 @@ set.seed(1)
 london_house_ids <- house_price_data %>%
   filter(
     region == "London",
-    transaction_id %in%
+    house_id %in%
       c(
-        "{1061746D-98D7-3C34-E063-4804A8C0F9E7}",
-        "{F5E8B081-90BE-3A13-E053-6C04A8C060B7}",
-        "{C18F412B-3F11-81A6-E053-6B04A8C0AD18}"
+        "0df4829d4e4c9b03",
+        "a48616c9efe00f38",
+        "75c9f976f797ab63"
       )
   )
 

--- a/book/scaled_effects.qmd
+++ b/book/scaled_effects.qmd
@@ -394,7 +394,7 @@ sales_controls <- arrow::read_parquet(
   root_path("data", "processed", "house_price.parquet")
 ) |>
   dplyr::select(
-    house_id, transaction_id, price, month_id, qtr_id,
+    house_id, price, month_id, qtr_id,
     latitude, longitude, lsoa, msoa, property_type, old_new, duration
   ) |>
   dplyr::mutate(
@@ -551,7 +551,7 @@ build_repeat_pairs <- function(market) {
     )
 
     transactions <- sales_controls |>
-      dplyr::select(house_id, transaction_id, price, qtr_id, latitude, longitude)
+      dplyr::select(house_id, price, qtr_id, latitude, longitude)
 
     lookup <- arrow::read_parquet(
       root_path("data", "processed", "spill_house_lookup.parquet")
@@ -567,7 +567,7 @@ build_repeat_pairs <- function(market) {
       dplyr::semi_join(lookup, by = "house_id") |>
       dplyr::inner_join(lookup, by = "house_id", relationship = "many-to-many") |>
       dplyr::inner_join(agg_spill, by = c("site_id", "qtr_id")) |>
-      dplyr::group_by(house_id, transaction_id, repeat_id, qtr_id, price, latitude, longitude) |>
+      dplyr::group_by(house_id, repeat_id, qtr_id, price, latitude, longitude) |>
       dplyr::summarise(
         spill_count_roll = sum(spill_count_roll, na.rm = TRUE),
         .groups = "drop"

--- a/docs/adr/0002-content-stable-transaction-identity.md
+++ b/docs/adr/0002-content-stable-transaction-identity.md
@@ -1,0 +1,23 @@
+# ADR 0002: Content-Stable Transaction Identity as Hex Strings
+
+- **Status:** Accepted
+- **Date:** 2026-08-14
+- **Implementation:** Completed on `jo/repeat-transactions-rebuild` on 2026-08-15;
+  all declared downstream ID artifacts passed the 100% source-match gate.
+
+## Context
+
+`rental_id` and `house_id` were positional row numbers assigned at cleaning time. Any upstream change to row count or order silently re-labelled every transaction, and downstream joins attached derived data to the wrong rows with no error. This produced two independent corruption episodes within thirteen months (rentals, July 2026; sales, August 2026). The repeat-group identifier (`repeat_id`) had the same defect one level up: sequential assignment made it unstable across runs and gave the rentals and sales mappings overlapping ranges.
+
+## Decision
+
+Transaction identity derives from content, not position. `rental_id` hashes the transaction's post-cleaning natural key; `house_id` hashes the Land Registry `transaction_id`; `repeat_id` hashes the normalised address key that defines the repeat group. All three are xxhash64 rendered as 16-character hex **strings**.
+
+Strings, not integers, deliberately: R silently coerces 64-bit integers to doubles above 2^53, corrupting joins invisibly, and a 32-bit space guarantees collisions at these row counts. String keys make every stale-generation join fail loudly (near-zero match rate) instead of succeeding wrongly. The Arrow schema contracts merged in PRs #28/#29 that pinned the ID columns to int32 now enforce `utf8`, consistent with this decision and the 2026-08-14 rebuild plan.
+
+## Consequences
+
+- Regeneration discipline is mandatory: any change to the hashed fields' cleaning transforms churns IDs, and every ID-keyed artifact must regenerate together. The failure mode for missing this is loud, by design.
+- Old positional-ID artifacts are retired by full regeneration, never bridged with crosswalks.
+- The same transaction carries the same ID in every artifact generation and in both the long-run superset and study-window subset tables, which is what makes the superset/subset design safe.
+- Considered and rejected: positional IDs guarded by provenance checks (leaves the root cause; guards rot), integer64 (silent double coercion), int32 (collision-certain).

--- a/docs/pipeline_documentation.md
+++ b/docs/pipeline_documentation.md
@@ -82,9 +82,15 @@ The main analysis scripts live separately in `scripts/R/09_analysis/`, while val
 - `repeat_sales.R` and `repeat_rentals.R`: thin market-specific entries over
   `scripts/R/utils/repeat_transactions_utils.R`. They build deterministic
   transaction-to-`repeat_id` mappings from the long-run cleaned supersets and
-  publish large-group and extreme-price-ratio review tables. Persisted
-  `repeat_count` is defined over the full long-run input; consumers that filter
-  the date window must regroup after filtering.
+  publish large-group, extreme-price-ratio, and same-day review tables. Two
+  transactions sharing an address and a date contradict each other, so every
+  conflicting row is excluded from the mapping and routed to the same-day
+  review; `repeat_count` is counted only over the survivors. The manifest
+  reports address-key completeness (`key_coverage`, `keyed_count`) separately
+  from same-day exclusion (`same_day_excluded_count`, `mapped_count`), because
+  the two measure different data-quality failures and carry different floors.
+  Persisted `repeat_count` is defined over the full long-run input; consumers
+  that filter the date window must regroup after filtering.
 
 ## Analysis Scripts
 

--- a/docs/pipeline_documentation.md
+++ b/docs/pipeline_documentation.md
@@ -25,8 +25,14 @@ The main analysis scripts live separately in `scripts/R/09_analysis/`, while val
 ### 02_data_cleaning
 
 - `clean_consented_discharges_database.R`: cleans the consented discharges database.
-- `clean_lr_house_price_data.R`: cleans Land Registry price-paid data using local ONS postcode data.
-- `clean_zoopla_data.R`: cleans safeguarded Zoopla rental data.
+- `clean_lr_house_price_data.R`: cleans one same-vintage 2014–2024 Land Registry
+  download, assigns content-stable string `house_id` values, and writes paired
+  long-run and 2021–2024 study-window candidates. The study window is always a
+  pure filter of the long-run table from the same run.
+- `clean_zoopla_data.R`: cleans safeguarded 2014–2023 Zoopla rental data,
+  removes exact duplicates, assigns content-stable string `rental_id` values,
+  and writes paired long-run and 2021–2023 study-window candidates. The study
+  window is always a pure filter of the long-run table from the same run.
 - `combine_annual_return_data.R`: combines annual return workbooks.
 - `convert_individ_raw_data_to_rdata.R`: converts historical EDM files into parquet outputs.
 - `process_edm_api_json_to_parquet_2024_onwards.R`: processes raw API snapshots into parquet outputs.
@@ -73,7 +79,12 @@ The main analysis scripts live separately in `scripts/R/09_analysis/`, while val
 - `house_panel_within_radius.R` and `rental_panel_within_radius.R`: build within-radius property panels.
 - `sale_panel_exp.R` and `rental_panel_exp.R`: export the general panel datasets.
 - `grid_long_difference_sales.R` and `grid_long_difference_rentals.R`: build grid-level long-difference datasets.
-- `repeat_sales.R` and `repeat_rentals.R`: build repeated-sales and repeated-rentals identifiers and summaries.
+- `repeat_sales.R` and `repeat_rentals.R`: thin market-specific entries over
+  `scripts/R/utils/repeat_transactions_utils.R`. They build deterministic
+  transaction-to-`repeat_id` mappings from the long-run cleaned supersets and
+  publish large-group and extreme-price-ratio review tables. Persisted
+  `repeat_count` is defined over the full long-run input; consumers that filter
+  the date window must regroup after filtering.
 
 ## Analysis Scripts
 
@@ -89,8 +100,13 @@ The `scripts/R/09_analysis/` folder contains the main descriptive, hedonic, repe
 ### Layer 02: Data Cleaning
 
 3. `clean_consented_discharges_database.R` — clean the consented discharges database.
-4. `clean_lr_house_price_data.R` — clean Land Registry house prices with local ONS postcode data.
-5. `clean_zoopla_data.R` — clean safeguarded Zoopla rentals with local ONS postcode data.
+4. `clean_lr_house_price_data.R` — create paired 2014–2024 long-run and
+   2021–2024 study-window Land Registry candidates in one run; promote the
+   validated candidates to `house_price_long_run.parquet` and
+   `house_price.parquet` together.
+5. `clean_zoopla_data.R` — create paired 2014–2023 long-run and 2021–2023
+   study-window Zoopla candidates in one run; promote the validated candidates
+   to `zoopla_rentals_long_run.parquet` and `zoopla_rentals.parquet` together.
 6. `combine_annual_return_data.R` — combine annual return workbooks.
 7. `convert_individ_raw_data_to_rdata.R` — convert standardised historical EDM files to parquet.
 8. `process_edm_api_json_to_parquet_2024_onwards.R` — process raw API JSON snapshots into parquet.
@@ -137,8 +153,8 @@ Integration scripts are executed earlier for dependency reasons; see steps 12 an
 36. `rental_panel_exp.R` — export the general rental panel.
 37. `grid_long_difference_sales.R` — build the sales long-difference grid dataset.
 38. `grid_long_difference_rentals.R` — build the rental long-difference grid dataset.
-39. `repeat_sales.R` — build repeated-sales identifiers and summaries.
-40. `repeat_rentals.R` — build repeated-rentals identifiers and summaries.
+39. `repeat_sales.R` — build the long-run sales repeat mapping and review tables.
+40. `repeat_rentals.R` — build the long-run rental repeat mapping and review tables.
 
 ## Dependency Notes
 
@@ -148,3 +164,6 @@ Integration scripts are executed earlier for dependency reasons; see steps 12 an
 - Step 11 is independent and only required for the `05_news` analysis.
 - Steps 17 to 21 form the rainfall and dry-spill sub-pipeline.
 - The layer-06 scripts build on spill aggregations and spatial matching outputs.
+- The cleaned long-run/study pairs are one atomic data generation: never rebuild
+  or promote one member independently. All ID-keyed artifacts must regenerate
+  after either pair changes.

--- a/docs/plans/2026-07-07-001-refactor-repeat-transactions-rebuild-plan.md
+++ b/docs/plans/2026-07-07-001-refactor-repeat-transactions-rebuild-plan.md
@@ -1,0 +1,241 @@
+---
+title: "refactor: Rebuild repeat_rentals and repeat_sales on content-stable IDs"
+type: refactor
+date: 2026-07-07
+---
+
+# refactor: Rebuild repeat_rentals and repeat_sales on content-stable IDs
+
+## Summary
+
+Rebuild `scripts/R/06_analysis_datasets/repeat_rentals.R` and `repeat_sales.R` as thin entry scripts over one shared parameterized pipeline module, keyed on content-stable transaction identifiers created upstream in the two cleaning scripts. Delete the distance-summary stage, restore the rental spill lookup to a 10 km radius, and regenerate every ID-keyed artifact so the whole `data/processed` tree sits on one ID generation.
+
+---
+
+## Problem Frame
+
+A validated multi-agent review (`todos/2026-07-07-review-repeat-rentals-sales.md`) proved an active data-integrity failure: `rental_id` and `house_id` are positional row numbers, and the shipped rentals mapping (built October 2025) is misaligned with the March 2026 input rebuild — 1,266 mapped ids exceed the current input's row count, so downstream joins silently attach repeat groups to the wrong transactions. Secondary defects: 3,453 exact-duplicate rows in the cleaned Zoopla data manufacture roughly 3,400 fake zero-gap repeat pairs; the distance summary (which nothing consumes) misclassifies every property with no site in radius and pools mapping-absent ids into one fake property; the twin scripts are hand-maintained duplicates; address keys embed literal `"NA"` text.
+
+All design decisions below were locked in the grilling session of 2026-07-07. Implementers must not re-open them; genuinely new information goes back to the user instead.
+
+---
+
+## Requirements
+
+**Identity and cleaning**
+
+- R1. `scripts/R/02_data_cleaning/clean_zoopla_data.R` removes exact duplicate rows (identical in all columns except `rental_id`) before ID assignment, logs the removed count, and records a spot-check of whether the duplicates originate in the raw inputs or are collapsed by cleaning.
+- R2. `rental_id` becomes a content-stable hash of seven source fields — `postcode`, `address_line_01`, `address_line_02`, `address_line_03`, `listing_price`, `latest_to_rent`, `rented` — taken at their post-cleaning values at the current ID-assignment point (after postcode normalisation, before any derived fields), matching the composite whose uniqueness was verified in the Evidence Base. The column keeps its name.
+- R3. `house_id` becomes a content-stable hash of the Land Registry `transaction_id`, keeping its column name; the `transaction_id` column is dropped from the cleaned output afterwards.
+- R4. The exact hash-input serialization (field order, NA token, separator, algorithm) is documented in code comments in both cleaning scripts so IDs are recomputable from source data. The documentation must note that recomputing an ID from raw source data requires reapplying the cleaning transforms first, since the hash consumes post-cleaning values.
+
+**Pipeline rebuild**
+
+- R5. A new shared module `scripts/R/utils/repeat_transactions_utils.R` holds the whole repeat-identification pipeline as pure functions over a config; `repeat_rentals.R` and `repeat_sales.R` shrink to thin entry scripts that source the shared bootstrap and the module, define a config, and call it.
+- R6. The mapping output has exactly three columns — the ID, `repeat_id`, `repeat_count` — at transaction grain with singles included, plus parquet key-value metadata recording input path, input row count, input modification time, and run timestamp. No pair metrics, no distance-summary stage, no spill-lookup input.
+- R7. The address-matching key is postcode + `paon` + `saon` + `street` (sales) and postcode + `address_line_01`–`03` (rentals), normalised by uppercasing, whitespace squishing, punctuation stripping, and empty-string substitution for missing components — never the literal text `"NA"`. Rows missing postcode or the primary address field carry no key. No fuzzy matching.
+- R8. The check battery (specified in U1's approach) runs on every execution, and a fixture contract test exists at `scripts/R/testing/test_repeat_transactions_contracts.R` following the repo's contract-test convention.
+
+**Radius resolution and regeneration**
+
+- R9. The rental spill lookup is rebuilt at `radius_km = 10` (the 5 km configuration was temporary), the house builder's conflicting internal radius defaults are reconciled to one explicit config value, and `todos/012-pending-p0-review-10km-site-match-scripts.md` is closed or updated accordingly.
+- R10. After the cleaning scripts rerun, every ID-keyed artifact regenerates in pipeline order, and consumers are updated: the `transaction_id` reference in `scripts/R/09_analysis/03_repeat_sales/repeat_sales.R`, plus any code found by a repo-wide search for `transaction_id` or for arithmetic on the ID columns. The pipeline execution-order documentation (`docs/pipeline_documentation.md`) reflects the new module.
+
+---
+
+## Key Technical Decisions
+
+- **Hash format is xxhash64 rendered as a 16-character hex string, not integer64:** R silently coerces 64-bit integers to doubles in many operations, corrupting values above 2^53 and breaking joins invisibly; strings fail loudly. Collision risk at 3.2M rows is about 1e-7 — negligible. Vectorise with `digest::getVDigest("xxhash64")`.
+- **Sales identity hashes `transaction_id` rather than using it verbatim:** format symmetry with rentals; provenance stays recoverable by recomputing the hash from Land Registry source data.
+- **Rentals identity keys the raw date fields (`latest_to_rent`, `rented`), not the derived `rented_est`:** `rented_est` is `coalesce(rented, latest_to_rent)` (`clean_zoopla_data.R:203`); keying the raw pair means a future change to the coalesce rule cannot churn IDs.
+- **Singles stay in the mapping with a `repeat_count` column:** the file remains a census of keyable transactions, so attrition is auditable by subtraction, and consumers filter repeats without regrouping.
+- **`street` stays in the sales key:** dropping it falsely merges same-numbered houses on different streets sharing a postcode (bias in the repeat-sales estimator); keeping it splits only 0.02% of groups via spelling variants (efficiency loss only). Punctuation stripping recovers the fixable subset.
+- **No coordinate-consistency check:** both datasets carry ONS postcode-centroid coordinates (verified: zero postcodes with more than one distinct coordinate), so a within-group check can never fire. Property-type consistency and extreme price-ratio flags are the false-merge alarms instead.
+- **The distance-summary stage is deleted, not fixed:** no script consumes either summary parquet, and three of the four high-severity review findings live in that stage. If the diagnostic is wanted later it becomes a standalone on-demand script.
+- **Old positional-ID artifacts are retired by full regeneration, not bridged:** stale hash-keyed joins fail loudly (near-zero match rate), which is the desired failure mode.
+
+---
+
+## Evidence Base
+
+Verified against the real data on 2026-07-07; implementers should reproduce a figure before relying on it.
+
+| Fact | Value |
+|------|-------|
+| `zoopla_rentals.parquet` rows | 1,450,255; 1,446,802 after exact-duplicate removal (3,453 excess rows in 3,324 groups, identical in every column except `rental_id`) |
+| Rentals natural key uniqueness | (postcode, address lines 1–3, `listing_price`, `latest_to_rent`, `rented`) exactly unique post-dedupe |
+| `house_price.parquet` rows | 3,175,951; `transaction_id` exactly unique |
+| Stale-mapping proof | shipped `repeated_rentals.parquet` max `rental_id` = 1,451,521 vs current input 1,450,255 rows; 1,266 ids nonexistent |
+| Street in sales key | adds 2,393 real distinctions; only 683 of 3.04M groups show >1 spelling; 41 collapse with punctuation stripping, ~35 likely typos, 369 genuinely different streets |
+| Coordinates | postcode centroids in both datasets (zero postcodes with >1 coordinate) |
+| Spill lookups | cover all properties with NA distance beyond radius (62,369 rentals at 5 km; 148,426 houses at 10 km); rentals builder configured at 5 km despite the 10 km name |
+| Key-field NAs | `rented` NA for ~1.04M rentals; `latest_to_rent` NA for ~35k; composite uniqueness verified with those NAs present |
+
+---
+
+## High-Level Technical Design
+
+The shared module processes either dataset through the same five stages; only the config differs.
+
+```mermaid
+flowchart TB
+  A[Cleaned input parquet<br/>column-selected read] --> B[Build address key<br/>normalise + guard]
+  B --> C[Group and assign<br/>repeat_id + repeat_count]
+  C --> D[Check battery<br/>fail-hard + warn-log]
+  D --> E[Write 3-column mapping<br/>+ metadata stamp]
+```
+
+Execution phases and their dependencies. The repeat mappings need only the cleaned inputs — the summary stage is gone, so Phase C and Phase D run in parallel.
+
+```mermaid
+flowchart TB
+  A[Phase A — U1: module + contract test<br/>green on fixtures] --> B[Phase B — U2 + U3: cleaning scripts<br/>dedupe + hashed IDs]
+  B --> GATE{User gate:<br/>counts + uniqueness verified}
+  GATE --> C[Phase C — U4: radius fix +<br/>regenerate spill lookups]
+  GATE --> D[Phase D — U5: run rebuilt<br/>repeat scripts]
+  C --> E[Phase E — U6: regenerate<br/>downstream artifacts]
+  D --> E
+  E --> F[Phase F — U7: consumer updates<br/>+ documentation]
+```
+
+---
+
+## Implementation Units
+
+### U1. Shared pipeline module and contract test
+
+- **Goal:** the whole repeat-identification pipeline exists as pure functions over a config, proven on synthetic fixtures before touching real data.
+- **Requirements:** R5, R6, R7, R8.
+- **Dependencies:** none.
+- **Files:** `scripts/R/utils/repeat_transactions_utils.R` (create), `scripts/R/testing/test_repeat_transactions_contracts.R` (create), `scripts/R/06_analysis_datasets/repeat_rentals.R` (rewrite as thin entry), `scripts/R/06_analysis_datasets/repeat_sales.R` (rewrite as thin entry).
+- **Approach:** module functions take (data, config) where config names the id column, date column, price column, address columns, paths, and log name. Column-selected loading via `arrow::read_parquet(col_select = ...)` plus `setDT()`; single-call grouped projection for `repeat_id` assignment (no full-width intermediate copies); `max()`-on-empty guarded with an explicit zero-row branch. The check battery: fail-hard input checks (schema, non-empty, id uniqueness, rentals zero-duplicates, dates in window), threshold checks (key-coverage floor with logged exclusion count; repeat groups above ~12 transactions written to a review file), fail-hard output checks (mapping id unique; mapping rows equal keyed input rows; `repeat_id` non-NA and finite; `repeat_count` reconciliation; metadata stamp present), and warn-only diagnostics (property-type consistency within groups, extreme annualised price-ratio pairs to a review file, repeat-share floor). R warnings route into the logger; plain non-colour log layout.
+- **Execution note:** test-first — the fixture contract test is written and failing before the module functions exist.
+- **Patterns to follow:** contract-test shape from `scripts/R/testing/test_merge_outputs_contracts.R`; sourced-utils pattern from `scripts/R/utils/spill_aggregation_utils.R`; bootstrap via `scripts/R/utils/script_setup.R` per `docs/solutions/best-practices/script-setup-runtime-package-cleanup-ingestion-20260310.md`; config-driven parameterization per `docs/solutions/design-patterns/parameterize-analysis-scripts-over-a-config-vector.md`.
+- **Test scenarios:**
+  - A fixture with two transactions at one address and one at another yields two `repeat_id` groups with `repeat_count` 2 and 1, singles included.
+  - A row missing the primary address field receives no key, is absent from the mapping, and the logged exclusion count equals 1.
+  - Missing secondary fields serialize as empty strings: a key built from (postcode, paon, NA saon, street) contains no literal `"NA"` text.
+  - Punctuation variants match: `"ST. JOHN'S ROAD"` and `"ST JOHNS ROAD"` produce identical keys.
+  - Zero-repeat input: every single gets a finite positive `repeat_id`; the finiteness assertion passes; no negative-infinity values.
+  - Duplicate input ids abort with the fail-hard uniqueness check.
+  - An input with a repeat group of 15 transactions lands in the collision review file without failing the run.
+  - Mixed property types within one group trigger the warn-log diagnostic, not a failure.
+  - The written parquet carries all four metadata fields and exactly three columns.
+  - Key coverage below the configured floor aborts; coverage above it logs the excluded count.
+- **Verification:** contract test green on fixtures; both entry scripts source and run against a fixture end-to-end without touching production data.
+
+### U2. Zoopla cleaning — dedupe and hashed rental_id
+
+- **Goal:** the cleaned rentals table is duplicate-free and carries a content-stable `rental_id`.
+- **Requirements:** R1, R2, R4.
+- **Dependencies:** U1 (so the downstream contract exists to test against).
+- **Files:** `scripts/R/02_data_cleaning/clean_zoopla_data.R` (modify).
+- **Approach:** remove exact duplicates (all columns except `rental_id`) before ID assignment; assign `rental_id` as the xxhash64 hex of the seven-field composite with a documented serialization (fixed field order, fixed NA token, fixed separator). Log the removed-duplicate count and write the raw-origin spot-check finding into the run log.
+- **Test scenarios:**
+  - Rerun produces exactly 1,446,802 rows (from 1,450,255) and the log records 3,453 removed.
+  - `rental_id` is unique across the full output.
+  - Hash determinism: recomputing the hash for a sample of 1,000 rows from their field values reproduces the stored `rental_id` exactly.
+  - Two runs of the script produce byte-identical `rental_id` columns (stability under re-execution).
+  - Rows with NA `rented` or NA `latest_to_rent` hash deterministically and remain unique.
+- **Verification:** row count, uniqueness, and determinism checks pass; duplicate-origin spot-check written up in the log or a short note.
+
+### U3. Land Registry cleaning — hashed house_id
+
+- **Goal:** the cleaned sales table carries a content-stable `house_id` and no `transaction_id` column.
+- **Requirements:** R3, R4.
+- **Dependencies:** U1.
+- **Files:** `scripts/R/02_data_cleaning/clean_lr_house_price_data.R` (modify).
+- **Approach:** `house_id` becomes xxhash64 hex of the Land Registry `transaction_id`; drop `transaction_id` from the output; document the hash input in a comment so provenance is recoverable by recomputation.
+- **Test scenarios:**
+  - Output has 3,175,951 rows and `house_id` is unique.
+  - `transaction_id` is absent from the output schema.
+  - Hash determinism: recomputing from a sample of source `transaction_id` values reproduces stored `house_id`.
+- **Verification:** row count preserved, uniqueness holds, schema check passes, and hash determinism holds (recomputing from source `transaction_id` values reproduces stored `house_id`).
+
+**User gate after U2 and U3:** confirm the counts and uniqueness results above with the user before any downstream regeneration begins.
+
+### U4. Radius resolution and spill-lookup regeneration
+
+- **Goal:** both spill lookups are rebuilt on the new IDs at an explicit, consistent 10 km radius, closing the pending radius P0.
+- **Requirements:** R9, R10 (partially — the two lookups).
+- **Dependencies:** U2, U3, user gate.
+- **Files:** `scripts/R/04_feature_engineering/10km_site_rental_match.R` (modify: `radius_km` 5 → 10), `scripts/R/04_feature_engineering/10km_site_house_sale_match.R` (modify: reconcile the conflicting internal radius defaults to one explicit config value), `todos/012-pending-p0-review-10km-site-match-scripts.md` (close or update).
+- **Approach:** make the radius a single explicit CONFIG value in each builder and log it at run time; regenerate both lookups.
+- **Test scenarios:**
+  - Regenerated rentals lookup has maximum non-NA distance just under 10,000 m; same for the sales lookup.
+  - Every ID in the corresponding cleaned input appears in its lookup (beyond-radius properties present with NA distance).
+  - Lookup IDs are 16-character hex strings joining cleanly back to the cleaned inputs with a 100% match rate.
+- **Verification:** the three checks above pass; the todos item is closed or updated with what was done.
+
+### U5. Run the rebuilt repeat scripts
+
+- **Goal:** fresh three-column mappings exist on the new IDs, with baselines recorded.
+- **Requirements:** R5, R6, R7, R8.
+- **Dependencies:** U2, U3, user gate. Runs in parallel with U4 — the pipeline no longer reads the spill lookups.
+- **Files:** `data/processed/repeated_transactions/` outputs (regenerate; archive the old mapping parquets first), `scripts/R/testing/test_repeat_transactions_contracts.R` (pin observed baselines).
+- **Approach:** archive `repeated_rentals.parquet` and `repeated_sales.parquet` (and the two now-orphaned `*_summary.parquet` files), run both entry scripts, record key-coverage and repeat-share baselines in the log and as pinned expectations in the contract test.
+- **Test scenarios:**
+  - Full check battery passes on both real datasets.
+  - Mapping row counts equal keyed input rows; logged exclusion counts equal input rows minus mapping rows.
+  - Spot check: one known repeat property (from the review's Birmingham sample or the log's largest legitimate group) resolves to a single `repeat_id`.
+- **Verification:** both runs complete with the battery green; baselines pinned; old artifacts archived, not deleted.
+
+### U6. Regenerate downstream ID-keyed artifacts
+
+- **Goal:** every artifact keyed on the old positional IDs is rebuilt on the new generation — no stale/fresh mixing anywhere in `data/processed`.
+- **Requirements:** R10.
+- **Dependencies:** U4, U5.
+- **Files:** the ID-keyed outputs of `scripts/R/06_analysis_datasets/` (cross-sections, panels, prior-to-sale and prior-to-rental datasets), regenerated by running those scripts in the order given by `docs/pipeline_documentation.md`; `docs/pipeline_documentation.md` (modify: reconcile the Layer 06 execution order before Phase E runs); a new standalone match-rate verification script under `scripts/R/testing/` (create).
+- **Approach:** before running anything, reconcile the Layer 06 execution order in `docs/pipeline_documentation.md` against the actual contents of `scripts/R/06_analysis_datasets/` — it currently lists only 12 of the 16 scripts, omitting `house_spill_prior_to_sale.R`, `rental_spill_prior_to_rental.R`, `repeat_rentals.R`, and `repeat_sales.R` — and include `house_spill_prior_to_sale.R` and `rental_spill_prior_to_rental.R` in the regeneration set (both are keyed on `house_id`/`rental_id`). Run the scripts unchanged in the corrected order. Match-rate checks run as a standalone verification script under `scripts/R/testing/` (following the `diff_*`/`reconcile_*` precedent, e.g. `diff_ch10_site_keyed_consumers.R`): it joins each regenerated artifact's ID column back to its cleaned input and fails on any match rate below 100% — a near-zero match rate indicates a missed regeneration upstream and stops the sequence.
+- **Test scenarios:** Test expectation: none — this unit executes existing scripts unchanged; correctness is carried by their own logs plus the standalone match-rate verification script.
+- **Verification:** the standalone verification script confirms every regenerated artifact's ID join back to its cleaned input matches at 100%; no script in the sequence errors or warns about missing ids.
+
+### U7. Consumer updates and documentation
+
+- **Goal:** all consumers work on the new IDs, and the plan's paper trail is closed out.
+- **Requirements:** R10.
+- **Dependencies:** U6.
+- **Files:** `scripts/R/09_analysis/03_repeat_sales/repeat_sales.R` (modify: remove the `transaction_id` select); the ~20 known consumers that deselect `transaction_id` and will hard-error after R3 — the live scripts under `scripts/R/09_analysis/02_hedonic/` (7) and `scripts/R/09_analysis/06_upstream_downstream/` (13) plus `scripts/R/testing/test_lsoa_variation_updown_prior.R` (modify); any further files surfaced by a repo-wide search for `transaction_id` or arithmetic on ID columns (modify as found); `docs/pipeline_documentation.md` (update: name the new module and refresh dependency notes — the Layer 06 run-list reconciliation itself happens in U6); `todos/2026-07-07-review-repeat-rentals-sales.md` (check off resolved findings).
+- **Approach:** grep-driven sweep for `transaction_id` and for integer-ID assumptions (`rental_id +`, `seq_len` over ids, `max(.*_id)`); fix each; rerun the affected 09_analysis outputs.
+- **Test scenarios:**
+  - The Palmquist script runs end-to-end on the new mappings and produces its regression table.
+  - Repo-wide search for `transaction_id` returns no live references outside the cleaning script's hash comment.
+- **Verification:** affected analyses rerun cleanly; `docs/pipeline_documentation.md` names the new module; review findings checked off with status notes.
+
+---
+
+## Execution Chunking (multi-thread)
+
+CH1 = U1. CH2 = U2 + U3 in one thread, ending at the user gate. After the gate, CH3 = U4 and CH4 = U5 in parallel. CH5 = U6 + U7 last. Do not launch CH3/CH4 before the gate clears.
+
+---
+
+## Scope Boundaries
+
+- No fuzzy or edit-distance address matching — decided against on bias grounds (false merges corrupt the estimator; splits only lose observations).
+- No change to downstream estimator logic: dropping extreme price-ratio pairs stays a decision inside the Palmquist analysis script; the mapping only flags them.
+- No semantic rename of `house_id` (it labels a transaction row, not a property); the grain is documented in the cleaning script instead of renamed across the repo.
+
+### Deferred to Follow-Up Work
+
+- A standalone on-demand diagnostic for "repeat properties near spill sites", replacing the deleted summary stage, if the descriptive statistics are wanted for the paper.
+- The wider `06_analysis_datasets` migration to the shared `script_setup.R` bootstrap and deduplicated helpers across the other 14 scripts (staged migration per the best-practices doc).
+- Deciding whether the canonical `scripts/R/utils/postcode_processing_utils.R` normaliser (which maps literal `"NA"` strings to missing) should replace local postcode handling repo-wide — a deliberate convergence, not a drop-in swap.
+
+---
+
+## Risks & Dependencies
+
+- **ID churn on cleaning-rule changes:** hashes key off cleaned field values, so a future change to address or postcode normalisation regenerates IDs. The failure is loud (match rates crater) but regeneration discipline becomes mandatory; the metadata stamp and match-rate logs are the tripwires.
+- **Rentals lookup at 10 km:** roughly four times the pair-table area of the 5 km build — expect a longer spatial join and a larger output. The existing 10 km house lookup is the scale reference.
+- **NA-heavy key fields:** `rented` is NA for about 1.04M rentals and `latest_to_rent` for about 35k. The NA token must serialize deterministically in the hash input; composite uniqueness was verified with those NAs present.
+- **Full-regeneration cost:** Phase E touches most of layer 06 and most of layer 09 (the ~20 `transaction_id`-deselecting consumers must be modified and rerun); `docs/pipeline_documentation.md` is the authority on sequence — U6 reconciles its Layer 06 run list before executing and U7 completes the documentation update, or the next contributor inherits a wrong map.
+
+---
+
+## Sources & Research
+
+- Review report and validated findings: `todos/2026-07-07-review-repeat-rentals-sales.md` (run artifacts under `/tmp/compound-engineering/ce-code-review/20260707-150922-3129613e/`, machine-local).
+- Radius P0: `todos/012-pending-p0-review-10km-site-match-scripts.md`.
+- Conventions: `docs/solutions/design-patterns/parameterize-analysis-scripts-over-a-config-vector.md`; `docs/solutions/best-practices/script-setup-runtime-package-cleanup-ingestion-20260310.md`; contract-test pattern in `scripts/R/testing/test_merge_outputs_contracts.R`.
+- Key code locations: `rented_est` derivation at `scripts/R/02_data_cleaning/clean_zoopla_data.R:203`; positional ID assignment at `clean_zoopla_data.R:262` and `scripts/R/02_data_cleaning/clean_lr_house_price_data.R:219`; downstream join at `scripts/R/09_analysis/03_repeat_sales/repeat_sales.R:99`.

--- a/docs/plans/2026-07-07-001-refactor-repeat-transactions-rebuild-plan.md
+++ b/docs/plans/2026-07-07-001-refactor-repeat-transactions-rebuild-plan.md
@@ -2,9 +2,12 @@
 title: "refactor: Rebuild repeat_rentals and repeat_sales on content-stable IDs"
 type: refactor
 date: 2026-07-07
+superseded_by: docs/plans/2026-08-14-001-refactor-repeat-transactions-consolidated-rebuild-plan.md
 ---
 
 # refactor: Rebuild repeat_rentals and repeat_sales on content-stable IDs
+
+> **SUPERSEDED (2026-08-14).** Do not implement from this document. The consolidated plan `docs/plans/2026-08-14-001-refactor-repeat-transactions-consolidated-rebuild-plan.md` replaces it after a second grilling session: U4 (radius fix) and U6's doc reconciliation were completed independently in August 2026; the evidence base was re-verified (the staleness flipped to the sales side, and the rebuilt sales input contains 65 mixed-vintage duplicate `transaction_id` pairs); and new decisions were added (hashed `repeat_id`, long-run superset/subset windows, int32 contract flips, invariants-vs-manifest testing). Decisions here remain valid only as restated there.
 
 ## Summary
 

--- a/docs/plans/2026-08-14-001-refactor-repeat-transactions-consolidated-rebuild-plan.md
+++ b/docs/plans/2026-08-14-001-refactor-repeat-transactions-consolidated-rebuild-plan.md
@@ -1,0 +1,193 @@
+---
+title: "refactor: Rebuild repeat transactions on content-stable IDs with long-run windows"
+type: refactor
+date: 2026-08-14
+supersedes: docs/plans/2026-07-07-001-refactor-repeat-transactions-rebuild-plan.md
+---
+
+# refactor: Rebuild repeat transactions on content-stable IDs with long-run windows
+
+## Summary
+
+Rebuild `scripts/R/06_analysis_datasets/repeat_rentals.R` and `repeat_sales.R` as thin entry scripts over one shared parameterized pipeline module, keyed on content-stable hashed identifiers created upstream in the two cleaning scripts. Extend both cleaned datasets to long-run windows (sales 2014–2024, rentals 2014–2023) as superset tables from which the existing study-window files are derived in the same run, leaving study-window consumers on their current paths with changes bounded by the R6a allowed-delta contract. Flip the six Arrow schema contracts that pin the ID columns to int32, regenerate every ID-keyed artifact in one dependency-ordered pass, and close out the review paper trail.
+
+All decisions were locked in grilling sessions (2026-07-07, 2026-08-14). Implementers must not re-open them; genuinely new information goes back to the user instead.
+
+## Problem Frame
+
+`rental_id` and `house_id` are positional row numbers (`clean_zoopla_data.R:262`, `clean_lr_house_price_data.R:219`): any upstream change to row count or order silently re-labels every transaction, which has caused two silent-misjoin episodes (rentals July 2026, sales August 2026 — the current sales mapping is misaligned with its rebuilt input). Secondary verified defects: exact-duplicate rows in cleaned rentals manufacture fake zero-gap repeat pairs; mixed-vintage raw Land Registry files put 65 `transaction_id`s in the sales input twice under different dates; the rentals cleaner selects rows by an OR across two date fields but time-indexes by a third, shipping out-of-window `qtr_id` values; the twin repeat scripts are hand-maintained duplicates; address keys embed literal `"NA"`; an unconsumed distance-summary stage misclassifies properties. Separately, repeat-sales is a long-run analysis needing history back to 2014, while the rest of the pipeline assumes the 2021–2024 study window and (verified by audit) enforces it nowhere — the window exists only as "which raw files the cleaner reads".
+
+## Requirements
+
+**Raw inputs and cleaning**
+
+- R1. All Land Registry raw files `pp-2014.csv` … `pp-2024.csv` come from **one download session** (same vintage; performed by the user). The cleaning script asserts `transaction_id` uniqueness fail-hard before ID assignment, so a mixed-vintage refresh dies loudly.
+- R2. `clean_lr_house_price_data.R` writes two outputs in one run: the canonical long-run superset `data/processed/house_price_long_run.parquet` (2014–2024) and the study-window file `data/processed/house_price.parquet` (2021–2024) **derived as a pure filter of the superset** — identical to today's file within the R6a allowed-delta contract. The subset is never built independently.
+- R3. `clean_zoopla_data.R` filters on `year(rented_est) %in% window` (the field that time-indexes rows), replacing the OR-across-two-fields filter, and writes superset `data/processed/zoopla/zoopla_rentals_long_run.parquet` (2014–2023) plus derived subset `data/processed/zoopla/zoopla_rentals.parquet` (2021–2023) under the same one-run discipline. Exact duplicate rows (identical in all columns except `rental_id`) are removed before ID assignment, with the removed count logged and a raw-versus-cleaning origin spot-check recorded.
+- R4. `rental_id` = xxhash64 hex of the seven-field post-cleaning composite (`postcode`, `address_line_01`, `address_line_02`, `address_line_03`, `listing_price`, `latest_to_rent`, `rented`), assigned in the superset so superset and subset carry identical ids. `house_id` = xxhash64 hex of `transaction_id`; the `transaction_id` column is dropped afterwards. Both scripts assert ID uniqueness fail-hard **at assignment time**.
+- R5. The hash-input serialization is implemented **once**, in a shared side-effect-free helper `scripts/R/utils/hash_utils.R` sourced by both cleaning scripts and the repeat module — field order as listed, UTF-8 encoding, dates formatted `%Y-%m-%d`, numerics via `format(scientific = FALSE, trim = TRUE)`, NA token and separator that cannot appear in the fields (asserted), lowercase 16-character hex output. `digest` joins the relevant `REQUIRED_PACKAGES` vectors (already locked: `rproject.toml:85`, `rv.lock:675`). Note that recomputing an ID from raw data requires reapplying the cleaning transforms first.
+- R6. `qtr_id`/`month_id` keep `base_year = 2021` everywhere. Negative values for pre-2021 superset rows are valid and documented; subset values stay bit-identical to today's for rows unaffected by the R6a deltas.
+- R6a. **Allowed-delta acceptance contract.** The derived study-window files match today's files exactly **except**: (a) `house_id`/`rental_id` become utf8 hash strings; (b) sales `transaction_id` is removed; (c) rentals lose exact-duplicate rows and shift by the quantified `rented_est` selection correction; (d) sales rows change only where the same-vintage refresh corrected dates. Paths, all other columns, values, and row membership are otherwise identical — verified at the gate by joining old to new sales rows via `xxhash64(old file's transaction_id)`; no retained crosswalk or audit ledger is needed because the hash is recomputable from the old file.
+- R6b. **Candidate-path discipline.** `data/` is Dropbox-shared and not branch-isolated, so both cleaners write all four outputs to candidate sibling paths (`*_candidate.parquet`). The gate reviews candidates while canonical files stay untouched; canonical replacement happens only after the gate clears, immediately before U4/U5 launch, so the shared tree never dwells in a mixed ID generation and the old files remain available for reconciliation.
+
+**Pipeline rebuild**
+
+- R7. A new shared module `scripts/R/utils/repeat_transactions_utils.R` holds the whole repeat-identification pipeline as pure functions over a config; `repeat_rentals.R` and `repeat_sales.R` shrink to thin entry scripts reading the **long-run supersets**. No distance-summary stage, no spill-lookup input.
+- R8. The mapping output has exactly three columns — the transaction ID, `repeat_id`, `repeat_count` — at transaction grain with singles included, under a declared literal Arrow schema (transaction ID utf8, `repeat_id` utf8, `repeat_count` int32). `repeat_id` = xxhash64 hex of the normalised address key (stable across runs, no sequential assignment). Distinct address keys map to distinct `repeat_id`s — asserted at build time while the key column is still in memory (`uniqueN(key) == uniqueN(repeat_id)`) rather than claimed collision-free by construction; a `repeat_id` is meaningful only within its market's mapping. `repeat_count` is defined over the long-run window; window-restricted uses must regroup (documented in the module and `CONCEPTS.md`).
+- R9. The address key is postcode + `paon` + `saon` + `street` (sales) and postcode + `address_line_01`–`03` (rentals), normalised by uppercasing, whitespace squishing, punctuation stripping, and empty-string substitution for missing components — never literal `"NA"`. Rows missing postcode or the primary address field (`paon` / `address_line_01`) carry no key and are excluded with a logged count. No fuzzy matching.
+- R10. Contract tests assert **invariants only**: ID uniqueness, mapping-rows-equal-keyed-input-rows, zero post-dedupe duplicates, `repeat_id` well-formed, key→`repeat_id` bijection, `repeat_count` reconciliation, key-coverage floor, metadata stamp present. Empirical thresholds (key-coverage floor, repeat-share floor, large-group size) are **named config parameters, not invented constants**: on the first long-run generation the coverage floor is set to a permissive construction-bug value, the observed coverage, repeat share, and group-size distribution are recorded as baselines in the manifest and presented at the gate, and operational floors are fixed with the user afterwards. Exact counts live in the run manifest (parquet key-value metadata: input path, input row count, input mtime, run timestamp, keyed/excluded counts) and are diffed against the previous run with a logged delta, not hard-failed; when no previous compatible manifest exists (the first hash generation), the diff logs "first generation" and is skipped. Fixture contract test at `scripts/R/testing/test_repeat_transactions_contracts.R`.
+
+**Consumers and regeneration**
+
+- R11. Six files pinning ID columns to int32 are flipped to `utf8` with coercions removed, **before** their artifacts regenerate: `scripts/R/utils/prior_exposure_utils.R`, `scripts/R/utils/cross_section_study_period_utils.R` (incl. its numeric-ID validator), `scripts/R/04_feature_engineering/site_house_sale_match.R` and `site_rental_match.R` (incl. `as.integer()` coercions), `scripts/R/testing/test_prior_exposure_contracts.R`, `test_cross_section_study_period_contracts.R`. The flips touch **only the transaction-ID columns** — `site_id`, `radius`, `n_site_groups`, and period-count fields remain int32 — and both updated contract suites must run green on character-ID fixtures (including an ID with a leading zero) **before** any production regeneration starts.
+- R12. After the gate, every ID-keyed artifact regenerates in one dependency-ordered pass and all consumers are updated: the 29 live `transaction_id`-referencing files, plus `rental_id`/`house_id` dtype and join-key assumptions in `scripts/R/09_analysis/05_news/` (18 files), `00_data_load/` (2, incl. the Python loader), `01_descriptive/` (2). A standalone match-rate verification script under `scripts/R/testing/` joins each regenerated artifact back to its cleaned input and fails below 100%. That check certifies **referential integrity only**: its near-zero failure signature for stale artifacts is specific to this one-time positional→hash transition, and each producer's own contract tests remain the completeness and correctness guarantee for future regenerations. `docs/pipeline_documentation.md` gains the module, the superset/subset outputs, and the one-run derivation rule.
+
+## Key Technical Decisions
+
+- **xxhash64 as 16-char hex string, not integer:** integer64 silently coerces to double above 2^53; int32 is collision-certain at these row counts; strings fail loudly. Vectorise with `digest::getVDigest("xxhash64")`. Deliberately overrides the int32 Arrow contracts from PRs #28/#29 — flip them, then they enforce the string regime. See `docs/adr/0002-content-stable-transaction-identity.md`.
+- **`repeat_id` derives from the address key:** identity-from-content one level up — kills the `max()`-on-empty/`-Inf` bug class, makes run-over-run diffs meaningful. Distinct-key → distinct-id is **asserted at build time**, not claimed by construction, and an id is meaningful only within its market's mapping.
+- **Superset + subset, derived in one run:** no downstream script enforces the study window, so extending the shared files in place would silently corrupt a dozen-plus consumers (wrong exposure denominators, decades-long DiD pre-periods, phantom FE levels). Content-stable IDs make the two-artifact design safe: the same transaction hashes identically in both.
+- **Windows 2014–2024 (sales) / 2014–2023 (rentals):** Zoopla raw starts 2014; windows aligned across markets. No partial years (registration lag bias).
+- **Same-vintage raw download is the duplicate fix; the assertion is the tripwire:** the 65 duplicate pairs are date corrections straddling year files of different vintages. Only a same-session download makes the *dates* correct; deduping would keep silently wrong dates — worse than a broken join for an estimator built on holding periods.
+- **Rentals filter on `rented_est`:** selection rule and time index must agree. Sample shifts slightly; quantified at the gate.
+- **Sales identity hashes `transaction_id` rather than using it verbatim:** format symmetry with rentals; provenance recoverable by recomputation.
+- **Rentals identity keys the raw date pair, not derived `rented_est`:** a future coalesce-rule change cannot churn IDs.
+- **Singles stay in the mapping with `repeat_count`:** the file is a census of keyable transactions; attrition auditable by subtraction.
+- **`street` stays in the sales key:** dropping it falsely merges same-numbered houses across streets (estimator bias); keeping it splits only ~0.02% of groups (efficiency loss only).
+- **No coordinate-consistency check:** both datasets carry ONS postcode-centroid coordinates, so a within-group check can never fire. Property-type consistency and extreme price-ratio flags are the false-merge alarms (warn-only).
+- **Tests assert invariants; manifests carry counts:** exact figures are snapshots of one input generation; pinning them makes green tests rot silently.
+- **Distance-summary stage deleted, not fixed;** old summary parquets archived. A standalone diagnostic can replace it later if wanted.
+- **Positional-ID artifacts retired by full regeneration, never bridged:** stale hash-keyed joins fail loudly (near-zero match rate) — the desired failure mode. No interim realignment of the stale sales mapping.
+- **The downstream estimator is out of scope:** `scripts/R/09_analysis/03_repeat_sales/repeat_sales.R` needs a `site_id` → Site Group migration unrelated to IDs; that plus its long-run redesign live in `todos/2026-08-14-repeat-sales-estimator-site-group-migration.md`. This plan's verification stops at the mapping boundary.
+
+## Evidence Base
+
+Verified 2026-08-14; reproduce before relying on. Figures for the 2014+ windows do not exist until the cleaning scripts first run — the gate verifies them.
+
+| Fact | Value |
+|------|-------|
+| `zoopla_rentals.parquet` (2021–2023) | 1,450,255 rows; 3,453 excess exact-duplicate rows in 3,324 groups; 1,446,802 after dedupe |
+| Rentals 7-field composite | exactly unique post-dedupe **on 2021–2023 only**; unverified on 2014–2023 — the fail-hard assertion is the check, a violation is a gate decision |
+| `house_price.parquet` (2021–2024) | 3,891,124 rows; 65 duplicate `transaction_id` pairs from mixed-vintage raw (retired by R1's re-download) |
+| Spill lookups | regenerated Aug 2026 **on positional IDs** — stale again after this rebuild; the ~5 GB house lookup is a multi-hour job and U5's critical path |
+
+## High-Level Technical Design
+
+The shared module processes either dataset through the same five stages; only the config differs.
+
+```mermaid
+flowchart TB
+  A[Long-run superset parquet<br/>column-selected read] --> B[Build address key<br/>normalise + guard]
+  B --> C[Group by key<br/>repeat_id = hash of key<br/>+ repeat_count]
+  C --> D[Check battery<br/>fail-hard invariants + manifest diff]
+  D --> E[Write 3-column mapping<br/>+ manifest stamp]
+```
+
+```mermaid
+flowchart TB
+  A[U1: module + contract test<br/>green on fixtures] --> B[U2 + U3: cleaning scripts<br/>same-vintage raw, superset+subset,<br/>hashed IDs, dedupe, rented_est filter]
+  B --> GATE{User gate:<br/>counts, uniqueness,<br/>sample shifts verified}
+  GATE --> C[U4: run rebuilt repeat scripts<br/>on the supersets]
+  GATE --> D[U5: flip int32 contracts, then<br/>regenerate all ID-keyed artifacts<br/>in dependency order]
+  C --> E[U6: consumer sweep,<br/>docs, paper-trail closeout]
+  D --> E
+```
+
+## Implementation Units
+
+### U1. Shared pipeline module and contract test
+
+- **Goal:** the whole repeat-identification pipeline exists as pure functions over a config, proven on synthetic fixtures before touching real data.
+- **Requirements:** R7, R8, R9, R10. **Dependencies:** none.
+- **Files:** `scripts/R/utils/repeat_transactions_utils.R` (create), `scripts/R/utils/hash_utils.R` (create — the R5 shared serializer/hash helper), `scripts/R/testing/test_repeat_transactions_contracts.R` (create), `scripts/R/06_analysis_datasets/repeat_rentals.R` and `repeat_sales.R` (rewrite as thin entries).
+- **Approach:** module functions take (data, config) where config names the id column, date column, price column, address columns (primary field identified), the optional property-type column (required by the property-type diagnostic), paths, and log name. Column-selected loading via `arrow::read_parquet(col_select = ...)` + `setDT()`; `repeat_id` assigned as the hash of the normalised address key in a single grouped projection (no full-width intermediate copies, no sequences, no `max()`). Check battery: fail-hard input checks (schema, non-empty, id uniqueness, zero exact duplicates, dates in window), threshold checks (key-coverage floor with logged exclusions, first-generation handling per R10; groups above ~12 transactions to a **large-group review file** — an address-quality audit, not a collision check), fail-hard output checks (mapping id unique; rows equal keyed input rows; `repeat_id` 16-char hex; distinct keys map one-to-one to `repeat_id`s, asserted while the key column is in memory; `repeat_count` reconciliation; manifest present), warn-only diagnostics (property-type consistency, extreme annualised price-ratio pairs to a review file, repeat-share floor), and a manifest diff against the previous run (logged delta, not a failure). R warnings route into the logger; plain non-colour log layout.
+- **Execution note:** test-first — the fixture contract test is written and failing before the module functions exist.
+- **Patterns:** contract-test shape from `scripts/R/testing/test_merge_outputs_contracts.R`; sourced-utils pattern from `scripts/R/utils/spill_aggregation_utils.R`; bootstrap via `scripts/R/utils/script_setup.R`; config-driven parameterization per `docs/solutions/design-patterns/parameterize-analysis-scripts-over-a-config-vector.md`.
+- **Test scenarios:**
+  - Two transactions at one address and one at another yield two `repeat_id`s with `repeat_count` 2 and 1, singles included; each `repeat_id` equals the recomputed hash of its normalised key.
+  - Two runs on the same fixture, and a run on the row-shuffled fixture, produce value-identical sorted three-column mappings; metadata is validated separately, with timestamps allowed to differ (no byte-for-byte parquet comparison).
+  - A row missing the primary address field gets no key, is absent from the mapping, and the logged exclusion count equals 1.
+  - A key built from (postcode, paon, NA saon, street) contains no literal `"NA"` text.
+  - `"ST. JOHN'S ROAD"` and `"ST JOHNS ROAD"` produce identical keys and `repeat_id`s.
+  - Zero-repeat input: every single carries a well-formed hashed `repeat_id`; no sentinel values.
+  - Duplicate input ids abort via the fail-hard uniqueness check.
+  - A 15-transaction group lands in the large-group review file without failing the run.
+  - Mixed property types within a group warn, not fail.
+  - The written parquet carries exactly three columns and the full manifest, re-read through the same Arrow API production will use, with every metadata key and value asserted; if the installed Arrow version cannot round-trip the metadata, escalate to the user rather than substituting a different contract.
+  - With no previous compatible manifest, the run logs "first generation" and skips the diff.
+  - Key coverage below the configured floor aborts (exercised via a fixture-specific config value); above it, the excluded count is logged.
+- **Verification:** contract test green on fixtures; both entry scripts run a fixture end-to-end without touching production data.
+
+### U2. Land Registry cleaning — same-vintage raw, superset + subset, hashed house_id
+
+- **Requirements:** R1, R2, R4, R5, R6, R6a, R6b. **Dependencies:** U1; the user's same-session download of `pp-2014.csv` … `pp-2024.csv` into `data/raw/lr_house_price/`. **Before the new files land**, the current Land Registry raw files are moved to a dated archive directory (kept, not deleted) and `shasum` checksums of both the old and new files are recorded in the gate log — the archived vintage is the only evidence of the 65 mixed-vintage duplicates. The user's same-session confirmation is gate testimony supplementing the checksums; a common file modification date proves nothing on a Dropbox-synced filesystem.
+- **Files:** `scripts/R/02_data_cleaning/clean_lr_house_price_data.R` (modify); `scripts/R/testing/test_cleaning_rebuild_contracts.R` (create, shared with U3 — durable superset/subset derivation and shared-run-stamp contract test); `scripts/R/testing/reconcile_cleaning_rebuild.R` (create, shared with U3 — one-off old-versus-new gate-evidence script following the `reconcile_*` precedent, not a permanent snapshot suite).
+- **Approach:** first verify the raw refresh — all eleven year files present, `transaction_id` globally unique across them, nonmissing and nonempty (if duplicates or missings remain, stop and report), `date_of_transfer` within 2014–2024. Then: `CONFIG$years = 2014:2024`; fail-hard `transaction_id` uniqueness; assert the postcode lookup is unique on `postcode` and enrichment is row-count preserving (many-to-one join); `house_id = xxhash64 hex(transaction_id)` via the shared R5 helper; drop `transaction_id`; fail-hard `house_id` uniqueness at assignment; write the superset, derive the subset by `year(date_of_transfer) %in% 2021:2024` — both to candidate paths per R6b. For the gate, report the old-versus-new transition — changes in `date_of_transfer`, `qtr_id`, `month_id`, and 2021–2024 membership, joined by hashing the old file's `transaction_id` — with the 65 previously duplicated IDs and their corrected retained records called out (the corrected dates are the payoff the re-download exists for; the gate must see them).
+- **Test scenarios:** a raw `transaction_id` duplicate aborts before any output; superset and subset carry identical `house_id` for the same transaction (spot-join); the subset matches today's file within the R6a allowed deltas, with `qtr_id` bit-identical for shared rows; hash determinism on a source-`transaction_id` sample; `transaction_id` absent from both output schemas.
+- **Verification:** vintage check passed; both candidate outputs written; uniqueness and determinism pass; row counts and the date-transition report logged for the gate.
+
+### U3. Zoopla cleaning — rented_est filter, dedupe, superset + subset, hashed rental_id
+
+- **Requirements:** R3, R4, R5, R6, R6a, R6b. **Dependencies:** U1 (raw Zoopla files already span 2014–2023; no new download).
+- **Files:** `scripts/R/02_data_cleaning/clean_zoopla_data.R` (modify); the two shared testing scripts created in U2.
+- **Approach:** replace the OR-filter with `year(rented_est) %in% CONFIG$years`; `CONFIG$years = 2014:2023`; remove exact duplicates before ID assignment (log count + raw-origin spot-check); assert the postcode lookup is unique on `postcode` and enrichment is row-count preserving (many-to-one join); assign `rental_id` as the composite hash via the shared R5 helper; fail-hard uniqueness at assignment — **if the composite is not unique on the extended window, stop and bring the collision profile to the gate rather than extending the composite unilaterally**; write superset, derive subset by `year(rented_est) %in% 2021:2023` — both to candidate paths per R6b.
+- **Test scenarios:** no output row has `year(rented_est)` outside its window (no negative `qtr_id` in the subset); superset and subset carry identical `rental_id` for the same row; rows with NA `rented` or `latest_to_rent` hash deterministically and stay unique; two runs produce byte-identical `rental_id` columns; the dedupe count and the filter-change sample shift are both logged.
+- **Verification:** uniqueness holds (or the collision profile is escalated); both candidate outputs written; the subset's sample delta versus the current file is quantified for the gate.
+
+**User gate after U2 and U3:** confirm with the user — vintage check result and raw-vintage checksums; superset/subset row counts for both datasets; rentals dedupe count and composite-uniqueness result on 2014–2023; sales `transaction_id` uniqueness result and the old-versus-new date/period/membership transition report; the rentals sample shift from the `rented_est` filter; the observed key-coverage/repeat-share baselines once U4 runs (threshold values fixed per R10); every delta checked against the R6a contract via `reconcile_cleaning_rebuild.R`. The gate reviews **candidate** files; canonical files are untouched until it clears. No downstream regeneration before the gate clears; promotion of the candidates to canonical paths happens immediately before U4/U5 launch.
+
+### U4. Run the rebuilt repeat scripts
+
+- **Requirements:** R7, R8, R9, R10. **Dependencies:** U2, U3, gate. Parallel with U5 (the pipeline does not read the spill lookups).
+- **Files:** `data/processed/repeated_transactions/` outputs (regenerate; U4 is the **sole owner** of the two mapping paths — U5 does not touch them).
+- **Approach:** read the previous mappings' manifests for the run diff **before** touching the files; run both entry scripts against the supersets, writing to stage paths; only after the full check battery passes, archive `repeated_rentals.parquet`, `repeated_sales.parquet`, and the two orphaned `*_summary.parquet` files to `data/processed/repeated_transactions/_archive/2026-08-14/` and promote the new mappings — a failed run must never leave the tree with no canonical mapping; record key-coverage and repeat-share baselines in the manifests and log.
+- **Verification:** full battery green on both real datasets; mapping rows equal keyed superset rows with exclusions reconciling by subtraction; spot check that one known repeat property resolves to a single `repeat_id` equal to the recomputed hash of its address key; old artifacts archived, not deleted.
+
+### U5. Type-contract flips and downstream regeneration
+
+- **Requirements:** R11, R12 (regeneration half). **Dependencies:** U2, U3, gate. Parallel with U4.
+- **Files:** the six R11 files (modify first); the ID-keyed outputs of `scripts/R/04_feature_engineering/` (both spill lookups) and `scripts/R/06_analysis_datasets/` (run unchanged in the order given by `docs/pipeline_documentation.md` — the 14 Layer-06 scripts **excluding** `repeat_sales.R` and `repeat_rentals.R`, which U4 owns exclusively); a new standalone match-rate verification script under `scripts/R/testing/` (create, following the `diff_*`/`reconcile_*` precedent).
+- **Approach:** flip int32 → `utf8` and remove `as.integer()` coercions **on the transaction-ID columns only** in the six files (adjacent legitimate int32 fields — `site_id`, `radius`, `n_site_groups`, period counts — stay integer) **before** running anything; run both updated contract suites green on character-ID fixtures, including a leading-zero ID, before launching any production regeneration; check free disk headroom before the house-lookup rebuild (16-character string IDs enlarge every transaction-site row of the ~5 GB artifact); then regenerate in dependency order: spill lookups first (the house lookup is the long pole), then cross-section/prior-exposure builders, then the remaining Layer-06 artifacts. The match-rate script joins each artifact's ID column back to its cleaned source and fails below 100% — a near-zero rate means a missed upstream regeneration and stops the sequence.
+- **Verification:** match-rate script reports 100% everywhere; updated contract tests pass; no script errors or warns about missing ids.
+
+### U6. Consumer sweep, documentation, and paper-trail closeout
+
+- **Requirements:** R12 (consumer half). **Dependencies:** U4, U5.
+- **Files:** `scripts/R/09_analysis/03_repeat_sales/repeat_sales.R` (remove the `transaction_id` selects at lines 95 and 198 **only** — the Site Group migration is out of scope); the remaining live `transaction_id` referencers — `scripts/R/09_analysis/02_hedonic/` (5), `06_upstream_downstream/` (12), `scripts/R/testing/test_lsoa_variation_updown_prior.R`, and the testing notebooks (`sales_repeat_purchases.qmd`, `sales_repeat_purchases2.qmd`, `rent_repeat_purchases.qmd`, `spill_count_variation_share_prior.qmd`, `test_house_price_sewage_merge.Rmd`); ID dtype/join assumptions in `05_news/` (18), `00_data_load/` (2, incl. `load_data_sewage.py`), `01_descriptive/` (2); `docs/pipeline_documentation.md` (module, superset/subset outputs, one-run derivation rule, removal of the summary-stage claims); both cleaner headers (paired long-run/study-window output lists); `docs/adr/0002-content-stable-transaction-identity.md` (implementation status); `docs/solutions/best-practices/script-setup-runtime-package-cleanup-ingestion-20260310.md` (correct the stale `renv::restore()` references to `rv sync`); `todos/2026-07-07-review-repeat-rentals-sales.md` (check off findings with status notes).
+- **Approach:** grep-driven sweep for `transaction_id`, integer-ID assumptions (`as.integer` on ids, arithmetic on ids, `seq_len` over ids, int32/int64 schema references), and mapping reads; for every mapping read found, confirm any window-restricted use regroups rather than consuming the long-run `repeat_count`, and note the check in the sweep record; fix each; rerun the affected 09_analysis outputs **except** the repeat-sales estimator (blocked on its own migration).
+- **Verification:** repo-wide search finds no live references to the Land Registry **source column** `transaction_id` (dependencies or type assumptions) outside the cleaning script's hash comment, with an explicit allow-list for the utilities' legitimate internal generic `transaction_id` variable names; no remaining integer pins on ID columns; affected analyses rerun cleanly; documentation updated; review findings checked off.
+
+## Execution Chunking (multi-thread)
+
+CH1 = U1. CH2 = U2 + U3 in one thread, ending at the user gate (U2 additionally waits on the raw download). After the gate, CH3 = U4 and CH4 = U5 — **sequential by default on a single machine**: the long-run volumes and the multi-hour ~5 GB lookup rebuild contend for memory and Dropbox-synced disk, and parallelism is permitted only on separate machines or with measured headroom. CH5 = U6 last. Do not launch CH3/CH4 before the gate clears.
+
+## Scope Boundaries
+
+- No estimator changes beyond the mechanical `transaction_id` removals — see `todos/2026-08-14-repeat-sales-estimator-site-group-migration.md`. Verification stops at the mapping boundary (join match rates, not regression tables).
+- No fuzzy or edit-distance address matching (false merges corrupt the estimator; splits only lose observations).
+- No study-window sample changes outside the R6a allowed deltas (the quantified `rented_est` filter fix, rental exact-duplicate removal, and sales rows corrected by the same-vintage refresh).
+- No semantic rename of `house_id` (it labels a transaction row, not a property); the grain is documented in the cleaning script.
+- No partial-year (2025+) data.
+
+### Deferred to Follow-Up Work
+
+- The repeat-sales estimator: Site Group migration, long-run window adoption, pair-filter methodology (own grilling session).
+- A standalone on-demand "repeat properties near spill sites" diagnostic, if wanted for the paper.
+- Wider `06_analysis_datasets` migration to the shared `script_setup.R` bootstrap.
+- Repo-wide convergence on the canonical postcode normaliser (`scripts/R/utils/postcode_processing_utils.R`).
+
+## Risks & Dependencies
+
+- **Rentals composite uniqueness on 2014–2023 is unverified:** the fail-hard assertion detects a violation; it stops U3 and goes to the gate for a deliberate composite extension.
+- **ID churn on cleaning-rule changes:** future normalisation changes regenerate IDs; failure is loud, regeneration discipline mandatory; manifests and the match-rate script are the tripwires.
+- **Superset/subset drift:** the subset must only ever be derived inside the cleaning run — enforced structurally (one script, two writes) and by contract test (subset = superset filtered to window; shared run stamp).
+- **Long-run volumes:** sales roughly doubles (~8–9M rows expected). The column-pruned data.table path covers the **repeat module only** — the Land Registry cleaner itself is eager (per-year import, `map_dfr`, full-width postcode join); watch memory on its first 11-year run, and check disk headroom before the lookup rebuild.
+- **`repeat_count` semantics:** defined over the long-run window; window-filtered consumers must regroup. Documented in the module, `CONCEPTS.md`, and the manifest.
+- **Raw download is a user dependency:** U2 starts with the vintage check and cannot run before the files land.
+
+## Sources
+
+- Superseded plan: `docs/plans/2026-07-07-001-refactor-repeat-transactions-rebuild-plan.md`. Validated review: `todos/2026-07-07-review-repeat-rentals-sales.md`.
+- Identity-regime ADR: `docs/adr/0002-content-stable-transaction-identity.md`. Vocabulary: `CONCEPTS.md` § Repeat-Transactions Area.
+- Conventions: `docs/solutions/design-patterns/parameterize-analysis-scripts-over-a-config-vector.md`; `docs/solutions/best-practices/script-setup-runtime-package-cleanup-ingestion-20260310.md` (its `renv::restore()` references are stale — `AGENTS.md` and the live `scripts/R/utils/script_setup.R` with `rv sync` are authoritative for this refactor; the doc is corrected in U6); `scripts/R/testing/test_merge_outputs_contracts.R`.
+- External review: GPT Pro plan review 2026-08-14 (`/tmp/oracle-repeat-review/review.md`), adjudicated by two independent adversarial verification passes against the codebase; the edits both passes endorsed are folded in above. Rejected by both passes: the per-producer dependency run table (P1-8) — regenerating all of Layer-06 in documented order is the deliberate omission-proof strategy. Explicitly not adopted (single-pass endorsement only): market-namespaced `repeat_id` preimages, input-content fingerprints in manifests, a full rental duplicate-provenance ledger, and producer-specific reconciliation suites.

--- a/docs/solutions/best-practices/script-setup-runtime-package-cleanup-ingestion-20260310.md
+++ b/docs/solutions/best-practices/script-setup-runtime-package-cleanup-ingestion-20260310.md
@@ -5,19 +5,19 @@ problem_type: best_practice
 component: tooling
 symptoms:
   - "Ingestion entry scripts duplicated dependency checks and logger setup."
-  - "Startup code in the ingestion layer had drifted away from the repo's `renv::restore()` contract."
+  - "Startup code in the ingestion layer had drifted away from the repo's `rv sync` contract."
   - "The API downloader depended on an implicit `%||%` helper that was not defined locally."
   - "There was no shared, approved bootstrap pattern for new R scripts."
 root_cause: missing_tooling
 resolution_type: tooling_addition
 severity: medium
-tags: [r, ingestion, tooling, script-setup, renv, logging, dependency-management]
+tags: [r, ingestion, tooling, script-setup, rv, logging, dependency-management]
 ---
 
 # Troubleshooting: Centralising R script setup for ingestion scripts without runtime installs
 
 ## Problem
-The ingestion layer had started to accumulate duplicated startup logic across entry scripts. `scripts/R/01_data_ingestion/fetch_edm_api_data_2024_onwards.R` and `scripts/R/01_data_ingestion/edm_individ_data_standardisation_2021-2023.R` each managed dependency checks and logging separately, and the broader cleanup goal was to move the repository toward a single fail-fast setup pattern based on `renv::restore()`.
+The ingestion layer had started to accumulate duplicated startup logic across entry scripts. `scripts/R/01_data_ingestion/fetch_edm_api_data_2024_onwards.R` and `scripts/R/01_data_ingestion/edm_individ_data_standardisation_2021-2023.R` each managed dependency checks and logging separately, and the broader cleanup goal was to move the repository toward a single fail-fast setup pattern based on `rv sync`.
 
 ## Environment
 - Module: EDM Ingestion
@@ -30,7 +30,7 @@ The ingestion layer had started to accumulate duplicated startup logic across en
 
 ## Symptoms
 - The two ingestion entry scripts duplicated startup concerns such as dependency checks and logger initialization.
-- The repository already documented `renv::restore()` as the intended dependency bootstrap path, but scripts still needed manual cleanup to fully align with that contract.
+- The repository documents `rv sync` as the dependency bootstrap path, but scripts still needed manual cleanup to fully align with that contract.
 - `fetch_edm_api_data_2024_onwards.R` relied on an implicit `%||%`-style null-coalescing behavior that was not defined locally.
 - There was no reusable helper to standardize startup when migrating the rest of `scripts/R/`.
 
@@ -45,7 +45,7 @@ The ingestion layer had started to accumulate duplicated startup logic across en
 The working fix was to split generic startup from script-specific logic.
 
 - Added `scripts/R/utils/script_setup.R` as the single shared helper for startup concerns.
-- Implemented `check_required_packages(required_packages)` to fail fast with a `renv::restore()` instruction instead of mutating the environment at runtime.
+- Implemented `check_required_packages(required_packages)` to fail fast with an `rv sync` instruction instead of mutating the environment at runtime.
 - Implemented `setup_logging(log_file, console = interactive(), threshold = "DEBUG")` to centralize logger initialization while keeping the existing log-file contract.
 - Refactored both ingestion scripts to:
   - require `here` up front so project-root sourcing is explicit
@@ -73,7 +73,7 @@ check_required_packages <- function(required_packages) {
       paste0(
         "Missing required packages: ",
         paste(missing_packages, collapse = ", "),
-        ". Install project dependencies first, e.g. `renv::restore()`."
+        ". Install project dependencies first with `rv sync`."
       ),
       call. = FALSE
     )
@@ -88,7 +88,7 @@ check_required_packages <- function(required_packages) {
 if (!requireNamespace("here", quietly = TRUE)) {
   stop(
     "Package `here` is required to run this script. ",
-    "Install project dependencies first, e.g. `renv::restore()`.",
+    "Install project dependencies first with `rv sync`.",
     call. = FALSE
   )
 }
@@ -127,14 +127,14 @@ The underlying problem was missing shared tooling. Each script had started to so
 This fix works because it restores one explicit contract:
 
 1. Generic startup lives in one helper rather than drifting across entry scripts.
-2. Missing dependencies now fail clearly and immediately, which matches the repository's documented `renv::restore()` workflow.
+2. Missing dependencies now fail clearly and immediately, which matches the repository's documented `rv sync` workflow.
 3. Logging is initialized consistently without changing the scripts' existing log file paths.
 4. The downloader no longer relies on an implicit operator from an attached package environment.
 5. The pattern is reusable for later migration across `scripts/R/` without changing script-specific business logic.
 
 ## Prevention
 - Treat `scripts/R/utils/script_setup.R` as the only approved place for generic dependency checks and logger initialization.
-- Do not use `install.packages()`, `renv::init()`, or broad `library()` calls inside production pipeline scripts.
+- Do not use `install.packages()`, mutate the project lockfile at runtime, or use broad `library()` calls inside production pipeline scripts.
 - Standardize on explicit `pkg::fn` usage in production scripts so dependencies remain visible and stable.
 - Keep utility files side-effect-light: sourcing a utility file should define helpers, not install packages or start work.
 - Start each production script with:
@@ -143,7 +143,7 @@ This fix works because it restores one explicit contract:
   - a `REQUIRED_PACKAGES` vector
   - `check_required_packages(REQUIRED_PACKAGES)`
   - a `LOG_FILE` constant when the script logs
-- Add a lightweight repository check such as `rg -n "install\\.packages\\(|renv::init\\(" scripts/R` during future cleanup passes.
+- Add a lightweight repository check such as `rg -n "install\\.packages\\(" scripts/R` during future cleanup passes.
 - Migrate the rest of `scripts/R/` in batches, starting with remaining `01_data_ingestion` and `02_data_cleaning` scripts before moving deeper into the pipeline.
 
 ## Related Issues

--- a/scripts/R/02_data_cleaning/clean_lr_house_price_data.R
+++ b/scripts/R/02_data_cleaning/clean_lr_house_price_data.R
@@ -2,22 +2,18 @@
 # HM Land Registry Price Paid Data Cleaner
 # ==============================================================================
 #
-# Purpose: Clean and combine HM Land Registry property sales data for 2021-2024,
-#          enrich with cached/geocoded postcode attributes, and write the
-#          canonical `house_price.parquet` output used by downstream sales
-#          analysis scripts.
-#
-# Author: Jacopo Olivieri
-# Date: 2025-01-14
-# Date Modified: 2026-03-10
+# Purpose: Clean one same-vintage 2014-2024 Land Registry download, enrich it
+#          with postcode attributes, assign content-stable transaction-grain
+#          `house_id` values, and write paired candidate datasets. The
+#          2021-2024 study file is always derived from the long-run table.
 #
 # Inputs:
-#   - data/raw/lr_house_price/pp-{year}.csv
+#   - data/raw/lr_house_price/pp-2014.csv ... pp-2024.csv
 #   - data/raw/uk_postcodes/2602_uk_postcodes.csv
-#   - scripts/R/utils/postcode_processing_utils.R
 #
-# Outputs:
-#   - data/processed/house_price.parquet
+# Candidate outputs (canonical files are never written by this script):
+#   - data/processed/house_price_long_run_candidate.parquet
+#   - data/processed/house_price_candidate.parquet
 #   - output/log/clean_lr_house_price_data.log
 #
 # Source:
@@ -34,9 +30,11 @@ if (!requireNamespace("here", quietly = TRUE)) {
 }
 
 source(here::here("scripts", "R", "utils", "script_setup.R"), local = TRUE)
+source(here::here("scripts", "R", "utils", "hash_utils.R"), local = TRUE)
 
 REQUIRED_PACKAGES <- c(
   "arrow",
+  "digest",
   "dplyr",
   "glue",
   "logger",
@@ -51,14 +49,30 @@ LOG_FILE <- here::here("output", "log", "clean_lr_house_price_data.log")
 
 check_required_packages(REQUIRED_PACKAGES)
 
-# Configuration
-############################################################
+CLEANING_MANIFEST_VERSION <- "1"
+LR_EXPECTED_YEARS <- 2014:2024
+CLEANING_METADATA_REQUIRED_KEYS <- c(
+  "cleaning_manifest_version",
+  "cleaning_run_stamp",
+  "cleaning_market",
+  "cleaning_artifact_role",
+  "cleaning_year_min",
+  "cleaning_year_max",
+  "cleaning_source_row_count",
+  "cleaning_parent_role"
+)
 
 CONFIG <- list(
-  years = 2021:2024,
-  base_year = 2021,
+  years = LR_EXPECTED_YEARS,
+  study_years = 2021:2024,
+  base_year = 2021L,
   input_dir = here::here("data", "raw", "lr_house_price"),
-  canonical_output_path = here::here("data", "processed", "house_price.parquet"),
+  long_run_candidate_path = here::here(
+    "data", "processed", "house_price_long_run_candidate.parquet"
+  ),
+  study_candidate_path = here::here(
+    "data", "processed", "house_price_candidate.parquet"
+  ),
   local_postcode_lookup_path = here::here(
     "data", "raw", "uk_postcodes", "2602_uk_postcodes.csv"
   ),
@@ -85,114 +99,319 @@ CONFIG <- list(
 # Setup Functions
 ############################################################
 
-#' Attach the required packages after fail-fast dependency checks
-#' @return NULL
 initialise_environment <- function() {
   invisible(lapply(REQUIRED_PACKAGES, function(pkg) {
     library(pkg, character.only = TRUE)
   }))
 }
 
-#' Sequential execution (no parallel plan) to avoid API rate/ordering issues
 setup_parallel <- function() {
   logger::log_info("Running sequentially (no future::multisession)")
 }
 
-#' Initialise logging for this script
-#' @return NULL
 initialise_logging <- function() {
   setup_logging(log_file = LOG_FILE, console = interactive(), threshold = "DEBUG")
   logger::log_info("Logging to {LOG_FILE}")
   logger::log_info("Script started at {Sys.time()}")
 }
 
-# Data Loading Functions
+# Data Loading and Validation
 ############################################################
 
-#' Load data for a specific year
-#' @param year Integer representing the year
-#' @return Tibble containing the raw data
-#' @throws error if file not found
-load_year_data <- function(year) {
-  file_path <- file.path(CONFIG$input_dir, glue::glue("pp-{year}.csv"))
+#' Validate the complete annual LR input set before reading any file
+#' @return Named character vector of input paths in configured year order
+validate_expected_lr_files <- function(input_dir, years) {
+  if (!identical(as.integer(years), as.integer(LR_EXPECTED_YEARS))) {
+    stop(
+      "Land Registry cleaning requires the exact 2014-2024 annual window.",
+      call. = FALSE
+    )
+  }
+  expected_names <- sprintf("pp-%d.csv", years)
+  expected_paths <- file.path(input_dir, expected_names)
+  missing_names <- expected_names[!file.exists(expected_paths)]
 
-  if (!file.exists(file_path)) {
-    err_msg <- glue::glue("File not found: {file_path}")
-    logger::log_error(err_msg)
-    stop(err_msg)
+  if (length(missing_names) > 0L) {
+    stop(
+      "Land Registry same-vintage input is incomplete. Missing exact annual file(s): ",
+      paste(missing_names, collapse = ", "),
+      ". Expected pp-2014.csv through pp-2024.csv from one download session.",
+      call. = FALSE
+    )
   }
 
-  logger::log_info("Loading data for year {year}")
+  stats::setNames(expected_paths, as.character(years))
+}
+
+parse_lr_transfer_date <- function(x) {
+  if (inherits(x, "POSIXt")) return(as.POSIXct(x, tz = "UTC"))
+  if (inherits(x, "Date")) return(as.POSIXct(x, tz = "UTC"))
+  lubridate::ymd_hm(x, quiet = TRUE, tz = "UTC")
+}
+
+#' Clean and standardize one annual source table
+clean_data <- function(df, year, base_year = CONFIG$base_year) {
+  if (ncol(df) != length(CONFIG$column_name_mapping)) {
+    stop(
+      "Land Registry file for ", year, " has ", ncol(df),
+      " columns; expected ", length(CONFIG$column_name_mapping), ".",
+      call. = FALSE
+    )
+  }
+
+  names(df) <- CONFIG$column_name_mapping
+
+  dplyr::mutate(
+    tibble::as_tibble(df),
+    postcode = stringr::str_remove_all(.data$postcode, stringr::fixed(" ")),
+    date_of_transfer = parse_lr_transfer_date(.data$date_of_transfer),
+    qtr_id = (lubridate::year(.data$date_of_transfer) - base_year) * 4L +
+      lubridate::quarter(.data$date_of_transfer),
+    month_id = (lubridate::year(.data$date_of_transfer) - base_year) * 12L +
+      lubridate::month(.data$date_of_transfer)
+  )
+}
+
+load_year_data <- function(year, file_path) {
+  logger::log_info("Loading Land Registry data for {year} from {file_path}")
   rio::import(file_path, setclass = "tbl")
 }
 
-#' Load data for all configured years
-#' @return Combined tibble of all years' data
-load_all_years <- function() {
-  logger::log_info("Starting data loading for years {paste(CONFIG$years, collapse=', ')}")
+#' Load only a path set already validated by `validate_expected_lr_files`
+load_all_years <- function(input_paths, base_year = CONFIG$base_year) {
+  expected_names <- sprintf("pp-%s.csv", names(input_paths))
+  if (!identical(basename(unname(input_paths)), expected_names)) {
+    stop("Land Registry input paths must be the validated exact annual files.", call. = FALSE)
+  }
 
-  map_dfr(CONFIG$years, function(year) {
-    load_year_data(year) %>%
-      clean_data(year)
+  purrr::map2_dfr(names(input_paths), unname(input_paths), function(year, path) {
+    clean_data(load_year_data(as.integer(year), path), as.integer(year), base_year)
   })
 }
 
-# Data Processing Functions
-############################################################
-
-#' Clean and standardize data for a single year
-#' @param df Data frame to clean
-#' @param year Year of the data
-#' @return Cleaned data frame
-clean_data <- function(df, year) {
-  colnames(df) <- CONFIG$column_name_mapping
-  base_year <- CONFIG$base_year
-
-  df %>%
-    mutate(
-      postcode = str_remove_all(postcode, fixed(" ")),     # Normalise for joins
-      date_of_transfer = ymd_hm(date_of_transfer),           # Parse timestamp
-      qtr_id = (lubridate::year(date_of_transfer) - base_year) * 4 +
-        lubridate::quarter(date_of_transfer),               # Quarter index
-      month_id = (lubridate::year(date_of_transfer) - base_year) * 12 +
-        lubridate::month(date_of_transfer)                  # Month index
+#' Fail hard on source identity and long-run date-window violations
+validate_lr_transactions <- function(data, years) {
+  required <- c("transaction_id", "date_of_transfer")
+  missing_columns <- setdiff(required, names(data))
+  if (length(missing_columns) > 0L) {
+    stop(
+      "Land Registry data is missing required column(s): ",
+      paste(missing_columns, collapse = ", "),
+      call. = FALSE
     )
+  }
+
+  transaction_id <- as.character(data$transaction_id)
+  if (anyNA(transaction_id)) {
+    stop("Land Registry transaction_id contains missing values.", call. = FALSE)
+  }
+  if (any(!nzchar(trimws(transaction_id)))) {
+    stop("Land Registry transaction_id contains empty values.", call. = FALSE)
+  }
+
+  duplicate_count <- sum(duplicated(transaction_id))
+  if (duplicate_count > 0L) {
+    stop(
+      "Land Registry transaction_id contains ", duplicate_count,
+      " duplicate row(s); the raw files are not a valid same-vintage set.",
+      call. = FALSE
+    )
+  }
+
+  transfer_year <- lubridate::year(data$date_of_transfer)
+  if (anyNA(transfer_year) || any(!transfer_year %in% years)) {
+    stop(
+      "Land Registry date_of_transfer must be non-missing and within ",
+      min(years), "-", max(years), ".",
+      call. = FALSE
+    )
+  }
+
+  invisible(data)
 }
 
-# Postcode processing utilities (shared across scripts)
-source(here::here("scripts", "R", "utils", "postcode_processing_utils.R"))
-
-# Export Functions
+# Postcode Enrichment and Output Construction
 ############################################################
 
-#' Export processed data to a single Parquet file
-#' @param df Data frame to export
-#' @param output_path Destination parquet path
-#' @return NULL
-export_data <- function(df, output_path) {
-  dir.create(dirname(output_path), recursive = TRUE, showWarnings = FALSE)
+assert_unique_postcode_lookup <- function(postcode_data) {
+  if (!("postcode" %in% names(postcode_data))) {
+    stop("Postcode lookup is missing `postcode`.", call. = FALSE)
+  }
+  if (anyDuplicated(postcode_data$postcode)) {
+    stop("Postcode lookup contains duplicate postcode keys.", call. = FALSE)
+  }
+  invisible(postcode_data)
+}
 
-  tryCatch(
-    {
-      arrow::write_parquet(df, output_path)
-      logger::log_info("Data exported successfully to Parquet file at {output_path}")
-    },
-    error = function(e) {
-      err_msg <- glue::glue("Failed to export data to Parquet at {output_path}: {e$message}")
-      logger::log_error(err_msg)
-      stop(err_msg)
-    }
+enrich_lr_postcodes <- function(data, postcode_data) {
+  assert_unique_postcode_lookup(postcode_data)
+  input_rows <- nrow(data)
+
+  enriched <- dplyr::left_join(data, postcode_data, by = "postcode")
+  if (nrow(enriched) != input_rows) {
+    stop(
+      "Land Registry postcode enrichment was not row-count preserving: ",
+      input_rows, " input rows became ", nrow(enriched), " rows.",
+      call. = FALSE
+    )
+  }
+
+  enriched
+}
+
+#' Assign stable transaction-grain IDs once, then derive the study subset
+build_lr_output_pair <- function(
+    enriched_data,
+    long_run_years = CONFIG$years,
+    study_years = CONFIG$study_years) {
+  validate_lr_transactions(enriched_data, long_run_years)
+
+  long_run <- enriched_data |>
+    dplyr::mutate(house_id = hash_transaction_id(.data$transaction_id)) |>
+    dplyr::relocate("house_id", .before = "transaction_id")
+
+  if (anyNA(long_run$house_id) || anyDuplicated(long_run$house_id)) {
+    stop("Hashed Land Registry house_id values must be non-missing and unique.", call. = FALSE)
+  }
+  if (any(!grepl("^[0-9a-f]{16}$", long_run$house_id))) {
+    stop("Hashed Land Registry house_id values must be lowercase 16-character hex.", call. = FALSE)
+  }
+
+  long_run <- dplyr::select(long_run, -dplyr::all_of("transaction_id"))
+  study <- dplyr::filter(
+    long_run,
+    lubridate::year(.data$date_of_transfer) %in% study_years
   )
+
+  list(long_run = long_run, study = study)
+}
+
+# Candidate Publication
+############################################################
+
+new_cleaning_run_stamp <- function(time = Sys.time()) {
+  format(as.POSIXct(time, tz = "UTC"), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+}
+
+cleaning_metadata <- function(
+    run_stamp,
+    market,
+    artifact_role,
+    years,
+    source_row_count,
+    parent_role) {
+  if (length(run_stamp) != 1L || is.na(run_stamp) || !nzchar(run_stamp)) {
+    stop("Cleaning run stamp must be one non-empty value.", call. = FALSE)
+  }
+  metadata <- list(
+    cleaning_manifest_version = CLEANING_MANIFEST_VERSION,
+    cleaning_run_stamp = as.character(run_stamp),
+    cleaning_market = as.character(market),
+    cleaning_artifact_role = as.character(artifact_role),
+    cleaning_year_min = as.character(min(years)),
+    cleaning_year_max = as.character(max(years)),
+    cleaning_source_row_count = as.character(source_row_count),
+    cleaning_parent_role = as.character(parent_role)
+  )
+
+  if (!all(CLEANING_METADATA_REQUIRED_KEYS %in% names(metadata))) {
+    stop("Cleaning metadata is incomplete.", call. = FALSE)
+  }
+  metadata
+}
+
+assert_candidate_output_path <- function(path) {
+  if (!grepl("_candidate\\.parquet$", basename(path))) {
+    stop(
+      "Cleaning outputs must use candidate sibling paths ending in `_candidate.parquet`; refusing: ",
+      path,
+      call. = FALSE
+    )
+  }
+  invisible(path)
+}
+
+write_cleaning_candidate <- function(data, path, metadata) {
+  assert_candidate_output_path(path)
+  dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
+
+  table <- arrow::Table$create(as.data.frame(data))
+  table$metadata <- metadata
+  stage_path <- tempfile(
+    pattern = paste0(".", basename(path), "-"),
+    tmpdir = dirname(path),
+    fileext = ".parquet"
+  )
+  on.exit(unlink(stage_path), add = TRUE)
+  arrow::write_parquet(table, stage_path)
+  if (!file.rename(stage_path, path)) {
+    stop("Failed to promote staged cleaning candidate to ", path, ".", call. = FALSE)
+  }
+  invisible(path)
+}
+
+write_lr_candidates <- function(
+    outputs,
+    long_run_path = CONFIG$long_run_candidate_path,
+    study_path = CONFIG$study_candidate_path,
+    run_stamp = new_cleaning_run_stamp()) {
+  if (!is.list(outputs) || !all(c("long_run", "study") %in% names(outputs))) {
+    stop("`outputs` must contain `long_run` and `study` data frames.", call. = FALSE)
+  }
+  if (identical(normalizePath(long_run_path, mustWork = FALSE),
+                normalizePath(study_path, mustWork = FALSE))) {
+    stop("Long-run and study candidates must use distinct paths.", call. = FALSE)
+  }
+  expected_study <- dplyr::filter(
+    outputs$long_run,
+    lubridate::year(.data$date_of_transfer) %in% CONFIG$study_years
+  )
+  if (!isTRUE(all.equal(
+    as.data.frame(expected_study),
+    as.data.frame(outputs$study),
+    check.attributes = FALSE
+  ))) {
+    stop(
+      "LR study candidate must be an unchanged filter of the long-run candidate.",
+      call. = FALSE
+    )
+  }
+
+  long_metadata <- cleaning_metadata(
+    run_stamp = run_stamp,
+    market = "sales",
+    artifact_role = "long_run",
+    years = CONFIG$years,
+    source_row_count = nrow(outputs$long_run),
+    parent_role = "raw_annual_files"
+  )
+  study_metadata <- cleaning_metadata(
+    run_stamp = run_stamp,
+    market = "sales",
+    artifact_role = "study",
+    years = CONFIG$study_years,
+    source_row_count = nrow(outputs$long_run),
+    parent_role = "long_run"
+  )
+
+  write_cleaning_candidate(outputs$long_run, long_run_path, long_metadata)
+  write_cleaning_candidate(outputs$study, study_path, study_metadata)
+
+  logger::log_info(
+    "Wrote paired LR candidates with run stamp {run_stamp}: long_run={nrow(outputs$long_run)}, study={nrow(outputs$study)}"
+  )
+
+  invisible(list(
+    long_run_path = long_run_path,
+    study_path = study_path,
+    run_stamp = run_stamp
+  ))
 }
 
 # Main Execution
 ############################################################
 
-#' Main execution function
-#' @param refresh_postcodes Boolean indicating whether to refresh postcode data
-#' @return NULL
 main <- function(refresh_postcodes = FALSE) {
-  # Setup
   initialise_environment()
   initialise_logging()
   setup_parallel()
@@ -201,37 +420,37 @@ main <- function(refresh_postcodes = FALSE) {
     "`refresh_postcodes` is ignored for LR builds; local postcode files are used instead."
   )
 
-  # Load and clean data
-  raw_data <- load_all_years()
+  # This is intentionally the first data operation: an incomplete annual set
+  # stops before rio reads even one large source file.
+  input_paths <- validate_expected_lr_files(CONFIG$input_dir, CONFIG$years)
+  raw_data <- load_all_years(input_paths, CONFIG$base_year)
+  validate_lr_transactions(raw_data, CONFIG$years)
+  logger::log_info(
+    "Validated {nrow(raw_data)} LR rows: transaction_id is complete and globally unique; dates lie within {min(CONFIG$years)}-{max(CONFIG$years)}."
+  )
 
-  # Build postcode enrichment using the local lookup keyed on postcode only
+  source(
+    here::here("scripts", "R", "utils", "postcode_processing_utils.R"),
+    local = TRUE
+  )
   postcode_result <- get_local_postcode_data_for_sales(
     raw_data,
     lookup_path = CONFIG$local_postcode_lookup_path
   )
-
-  # Merge postcode attributes and add a stable house identifier
-  final_data <- left_join(
-    raw_data,
-    postcode_result$postcode_data,
-    by = "postcode"
-  ) %>%
-    mutate(house_id = row_number()) %>%
-    relocate(house_id, .before = transaction_id)
-
-  export_data(final_data, CONFIG$canonical_output_path)
+  final_data <- enrich_lr_postcodes(raw_data, postcode_result$postcode_data)
+  outputs <- build_lr_output_pair(final_data, CONFIG$years, CONFIG$study_years)
+  publication <- write_lr_candidates(outputs)
 
   logger::log_info("Script finished at {Sys.time()}")
 
-  invisible(
-    list(
-      output_path = CONFIG$canonical_output_path,
-      diagnostics = postcode_result$diagnostics
-    )
-  )
+  invisible(list(
+    output_paths = publication[c("long_run_path", "study_path")],
+    run_stamp = publication$run_stamp,
+    row_counts = c(long_run = nrow(outputs$long_run), study = nrow(outputs$study)),
+    diagnostics = postcode_result$diagnostics
+  ))
 }
 
-# Execute main function if script is run directly
 if (sys.nframe() == 0) {
   main(refresh_postcodes = FALSE)
 }

--- a/scripts/R/02_data_cleaning/clean_zoopla_data.R
+++ b/scripts/R/02_data_cleaning/clean_zoopla_data.R
@@ -71,10 +71,6 @@ CLEANING_METADATA_REQUIRED_KEYS <- c(
   "cleaning_source_row_count",
   "cleaning_parent_role"
 )
-RENTAL_IDENTITY_FIELDS <- c(
-  "postcode", "address_line_01", "address_line_02", "address_line_03",
-  "listing_price", "latest_to_rent", "rented"
-)
 
 # Configuration
 ############################################################

--- a/scripts/R/02_data_cleaning/clean_zoopla_data.R
+++ b/scripts/R/02_data_cleaning/clean_zoopla_data.R
@@ -2,9 +2,9 @@
 # CDRC Zoopla Rental Transactions Data Cleaner
 # ==============================================================================
 #
-# Purpose: Clean and combine safeguarded Zoopla rental listings for 2021-2023,
-#          enrich them with postcode attributes, and export the canonical
-#          rental panel used by downstream sewage and housing analyses.
+# Purpose: Clean safeguarded Zoopla rental listings for 2014-2023, remove exact
+#          duplicates, assign content-stable transaction IDs, and write paired
+#          long-run/study candidates from one build.
 #
 # Author: Jacopo Olivieri
 # Date: 2025-09-02
@@ -16,8 +16,9 @@
 #   - data/raw/uk_postcodes/2602_uk_postcodes.csv
 #   - scripts/R/utils/postcode_processing_utils.R
 #
-# Outputs:
-#   - data/processed/zoopla/zoopla_rentals.parquet
+# Candidate outputs (canonical files are never written by this script):
+#   - data/processed/zoopla/zoopla_rentals_long_run_candidate.parquet
+#   - data/processed/zoopla/zoopla_rentals_candidate.parquet
 #   - output/log/clean_zoopla_data.log
 #
 # Source:
@@ -34,10 +35,12 @@ if (!requireNamespace("here", quietly = TRUE)) {
 }
 
 source(here::here("scripts", "R", "utils", "script_setup.R"), local = TRUE)
+source(here::here("scripts", "R", "utils", "hash_utils.R"), local = TRUE)
 
 REQUIRED_PACKAGES <- c(
   "arrow",
   "data.table",
+  "digest",
   "dplyr",
   "fs",
   "glue",
@@ -57,13 +60,30 @@ source(
   local = TRUE
 )
 
+CLEANING_MANIFEST_VERSION <- "1"
+CLEANING_METADATA_REQUIRED_KEYS <- c(
+  "cleaning_manifest_version",
+  "cleaning_run_stamp",
+  "cleaning_market",
+  "cleaning_artifact_role",
+  "cleaning_year_min",
+  "cleaning_year_max",
+  "cleaning_source_row_count",
+  "cleaning_parent_role"
+)
+RENTAL_IDENTITY_FIELDS <- c(
+  "postcode", "address_line_01", "address_line_02", "address_line_03",
+  "listing_price", "latest_to_rent", "rented"
+)
+
 # Configuration
 ############################################################
 
 CONFIG <- list(
   # Time-frame
-  years = 2021:2023,
-  base_year = 2021,
+  years = 2014:2023,
+  study_years = 2021:2023,
+  base_year = 2021L,
   # Data retention options
   keep_address_line_1 = TRUE,  # Toggle to FALSE to exclude address data
   # Input file paths
@@ -73,8 +93,11 @@ CONFIG <- list(
   ),
   
   # Output file paths
-  canonical_output_path = here::here(
-    "data", "processed", "zoopla", "zoopla_rentals.parquet"
+  long_run_candidate_path = here::here(
+    "data", "processed", "zoopla", "zoopla_rentals_long_run_candidate.parquet"
+  ),
+  study_candidate_path = here::here(
+    "data", "processed", "zoopla", "zoopla_rentals_candidate.parquet"
   ),
   # Column renaming map: old_name = new_name
   column_name_mapping = c(
@@ -145,42 +168,26 @@ load_data <- function(file_path = CONFIG$input_dir) {
   tibble::as_tibble(df)
 }
 
-#' Export Zoopla Rental Data to Parquet
-#'
-#' Writes the canonical rentals parquet to `data/processed/zoopla`.
-#'
-#' @param df Cleaned tibble from `clean_zoopla_data()`
-#' @param output_path Optional override of the default output path.
-#'   Defaults to `CONFIG$canonical_output_path`.
-#' @return Full output file path (returned invisibly).
-export_zoopla_data <- function(
-  df,
-  output_path = CONFIG$canonical_output_path
-) {
-  # Ensure output directory exists
-  dir.create(dirname(output_path), recursive = TRUE, showWarnings = FALSE)
-
-  logger::log_info("Exporting data to: {output_path}")
-  arrow::write_parquet(df, output_path)
-
-  invisible(output_path)
-}
-
 #' Clean Zoopla Rental Data
 #'
-#' - Filters observations to CONFIG$years when either `zp.LatestToRent` or
-#'   `zp.Rented` falls within those years (robust to date/year formats).
+#' - Forms `rented_est` as coalesce(rented, latest_to_rent), then filters only
+#'   on the year of that same field so selection and time indexing agree.
 #' - Renames variables to snake_case, aligning with LR naming where possible.
 #'
 #' @param df Tibble returned by `load_data()`
+#' @param years Inclusive years retained in the long-run output.
+#' @param track_raw_origin Keep a temporary source-row index for dedupe evidence.
 #' @return Cleaned tibble
-clean_zoopla_data <- function(df) {
-  df %>%
-    # Filter to study years by either rented or latest_to_rent
-    filter(
-      lubridate::year(`zp.LatestToRent`) %in% CONFIG$years |
-        lubridate::year(`zp.Rented`) %in% CONFIG$years
-    ) %>%
+clean_zoopla_data <- function(
+    df,
+    years = CONFIG$years,
+    track_raw_origin = FALSE) {
+  data <- tibble::as_tibble(df)
+  if (isTRUE(track_raw_origin)) {
+    data <- dplyr::mutate(data, .raw_origin_row = dplyr::row_number())
+  }
+
+  data %>%
     # Drop address lines (postcode retained, optionally keep Address1)
     {if (CONFIG$keep_address_line_1) {
       select(., -matches("zp\\.Address[4-9]"))  # Keep Address1, remove others
@@ -202,6 +209,7 @@ clean_zoopla_data <- function(df) {
       postcode = stringr::str_remove_all(postcode, stringr::fixed(" ")),
       rented_est = dplyr::coalesce(rented, latest_to_rent)
     ) %>%
+    filter(lubridate::year(rented_est) %in% years) %>%
     # LR‑aligned time IDs from rented_est
     mutate(
       qtr_id = (lubridate::year(rented_est) - CONFIG$base_year) * 4 + lubridate::quarter(rented_est),
@@ -219,6 +227,255 @@ clean_zoopla_data <- function(df) {
         property_type == "BUNGALOW" ~ "B"
       )
     )
+}
+
+#' Remove rows identical across every post-cleaning field
+#'
+#' A temporary raw-row index is excluded from equality and removed from output.
+#' One duplicate group's source rows are retained as a logged origin spot check.
+deduplicate_zoopla_transactions <- function(data, raw_data = NULL) {
+  data <- tibble::as_tibble(data)
+  origin_column <- intersect(".raw_origin_row", names(data))
+  comparison_columns <- setdiff(names(data), c("rental_id", origin_column))
+  if (length(comparison_columns) == 0L) {
+    stop("Zoopla dedupe requires post-cleaning columns.", call. = FALSE)
+  }
+
+  comparison <- data.table::as.data.table(data[comparison_columns])
+  removed <- duplicated(comparison, by = comparison_columns)
+  duplicate_members <- removed |
+    duplicated(comparison, by = comparison_columns, fromLast = TRUE)
+  duplicate_group_count <- if (any(duplicate_members)) {
+    data.table::uniqueN(
+      comparison[duplicate_members],
+      by = comparison_columns
+    )
+  } else {
+    0L
+  }
+
+  origin_spot_check <- tibble::tibble()
+  if (any(duplicate_members) && length(origin_column) == 1L) {
+    first_member <- which(duplicate_members)[[1]]
+    sample_group <- comparison[first_member]
+    same_group <- comparison[
+      sample_group,
+      on = comparison_columns,
+      which = TRUE,
+      nomatch = 0L
+    ]
+    origin_rows <- as.integer(data$.raw_origin_row[same_group])
+    raw_rows_identical <- NA
+    if (!is.null(raw_data) && all(origin_rows %in% seq_len(nrow(raw_data)))) {
+      raw_sample <- as.data.frame(raw_data[origin_rows, , drop = FALSE])
+      raw_columns <- setdiff(names(raw_sample), c("V1", "cdrc.File"))
+      raw_rows_identical <- nrow(unique(raw_sample[raw_columns])) == 1L
+    }
+    origin_spot_check <- tibble::tibble(
+      .raw_origin_row = origin_rows,
+      raw_rows_identical = raw_rows_identical
+    )
+  }
+
+  deduplicated <- data[!removed, , drop = FALSE]
+  deduplicated <- dplyr::select(
+    deduplicated,
+    -dplyr::any_of(".raw_origin_row")
+  )
+
+  list(
+    data = deduplicated,
+    removed_count = as.integer(sum(removed)),
+    duplicate_group_count = as.integer(duplicate_group_count),
+    origin_spot_check = origin_spot_check
+  )
+}
+
+assert_unique_postcode_lookup <- function(postcode_data) {
+  if (!("postcode" %in% names(postcode_data))) {
+    stop("Postcode lookup is missing `postcode`.", call. = FALSE)
+  }
+  if (anyDuplicated(postcode_data$postcode)) {
+    stop("Postcode lookup contains duplicate postcode keys.", call. = FALSE)
+  }
+  invisible(postcode_data)
+}
+
+enrich_zoopla_postcodes <- function(data, postcode_data) {
+  assert_unique_postcode_lookup(postcode_data)
+  input_rows <- nrow(data)
+  enriched <- dplyr::left_join(data, postcode_data, by = "postcode")
+  if (nrow(enriched) != input_rows) {
+    stop(
+      "Zoopla postcode enrichment was not row-count preserving: ",
+      input_rows, " input rows became ", nrow(enriched), " rows.",
+      call. = FALSE
+    )
+  }
+  enriched
+}
+
+assert_rental_identity_unique <- function(data) {
+  missing_fields <- setdiff(RENTAL_IDENTITY_FIELDS, names(data))
+  if (length(missing_fields) > 0L) {
+    stop(
+      "Zoopla identity is missing composite field(s): ",
+      paste(missing_fields, collapse = ", "),
+      call. = FALSE
+    )
+  }
+  serialized <- serialize_hash_fields(data, RENTAL_IDENTITY_FIELDS)
+  duplicate_composite <- duplicated(serialized) | duplicated(serialized, fromLast = TRUE)
+  if (any(duplicate_composite)) {
+    profile <- data[duplicate_composite, RENTAL_IDENTITY_FIELDS, drop = FALSE] |>
+      dplyr::count(dplyr::across(dplyr::everything()), name = "rows") |>
+      dplyr::arrange(dplyr::desc(.data$rows)) |>
+      dplyr::slice_head(n = 5L)
+    stop(
+      "Zoopla seven-field rental identity composite is not unique (",
+      sum(duplicated(serialized)), " excess row(s); sample profile: ",
+      paste(capture.output(print(profile)), collapse = " "), ").",
+      call. = FALSE
+    )
+  }
+  invisible(serialized)
+}
+
+#' Assign rental IDs in the superset and derive the study subset unchanged
+build_zoopla_output_pair <- function(
+    enriched_data,
+    long_run_years = CONFIG$years,
+    study_years = CONFIG$study_years) {
+  data <- tibble::as_tibble(enriched_data)
+  rented_year <- lubridate::year(data$rented_est)
+  if (anyNA(rented_year) || any(!rented_year %in% long_run_years)) {
+    stop(
+      "Zoopla rented_est must be non-missing and within ",
+      min(long_run_years), "-", max(long_run_years), ".",
+      call. = FALSE
+    )
+  }
+
+  assert_rental_identity_unique(data)
+  long_run <- data |>
+    dplyr::mutate(rental_id = hash_rental_identity(data)) |>
+    dplyr::relocate("rental_id", .before = 1)
+  if (anyNA(long_run$rental_id) || anyDuplicated(long_run$rental_id)) {
+    stop("Hashed Zoopla rental_id values must be non-missing and unique; possible hash collision.", call. = FALSE)
+  }
+  if (any(!grepl("^[0-9a-f]{16}$", long_run$rental_id))) {
+    stop("Hashed Zoopla rental_id values must be lowercase 16-character hex.", call. = FALSE)
+  }
+
+  study <- dplyr::filter(
+    long_run,
+    lubridate::year(.data$rented_est) %in% study_years
+  )
+  list(long_run = long_run, study = study)
+}
+
+new_cleaning_run_stamp <- function(time = Sys.time()) {
+  format(as.POSIXct(time, tz = "UTC"), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+}
+
+cleaning_metadata <- function(
+    run_stamp,
+    market,
+    artifact_role,
+    years,
+    source_row_count,
+    parent_role,
+    removed_duplicate_count) {
+  metadata <- list(
+    cleaning_manifest_version = CLEANING_MANIFEST_VERSION,
+    cleaning_run_stamp = as.character(run_stamp),
+    cleaning_market = as.character(market),
+    cleaning_artifact_role = as.character(artifact_role),
+    cleaning_year_min = as.character(min(years)),
+    cleaning_year_max = as.character(max(years)),
+    cleaning_source_row_count = as.character(source_row_count),
+    cleaning_parent_role = as.character(parent_role),
+    cleaning_removed_duplicate_rows = as.character(removed_duplicate_count)
+  )
+  if (!all(CLEANING_METADATA_REQUIRED_KEYS %in% names(metadata))) {
+    stop("Cleaning metadata is incomplete.", call. = FALSE)
+  }
+  metadata
+}
+
+assert_candidate_output_path <- function(path) {
+  if (!grepl("_candidate\\.parquet$", basename(path))) {
+    stop(
+      "Cleaning outputs must use candidate sibling paths ending in `_candidate.parquet`; refusing: ",
+      path,
+      call. = FALSE
+    )
+  }
+  invisible(path)
+}
+
+write_cleaning_candidate <- function(data, path, metadata) {
+  assert_candidate_output_path(path)
+  dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
+  table <- arrow::Table$create(as.data.frame(data))
+  table$metadata <- metadata
+  stage_path <- tempfile(
+    pattern = paste0(".", basename(path), "-"),
+    tmpdir = dirname(path),
+    fileext = ".parquet"
+  )
+  on.exit(unlink(stage_path), add = TRUE)
+  arrow::write_parquet(table, stage_path)
+  if (!file.rename(stage_path, path)) {
+    stop("Failed to promote staged cleaning candidate to ", path, ".", call. = FALSE)
+  }
+  invisible(path)
+}
+
+write_zoopla_candidates <- function(
+    outputs,
+    long_run_path = CONFIG$long_run_candidate_path,
+    study_path = CONFIG$study_candidate_path,
+    run_stamp = new_cleaning_run_stamp(),
+    source_row_count = nrow(outputs$long_run),
+    removed_duplicate_count = 0L) {
+  if (!is.list(outputs) || !all(c("long_run", "study") %in% names(outputs))) {
+    stop("`outputs` must contain `long_run` and `study` data frames.", call. = FALSE)
+  }
+  if (identical(normalizePath(long_run_path, mustWork = FALSE),
+                normalizePath(study_path, mustWork = FALSE))) {
+    stop("Long-run and study candidates must use distinct paths.", call. = FALSE)
+  }
+  expected_study <- dplyr::filter(
+    outputs$long_run,
+    lubridate::year(.data$rented_est) %in% CONFIG$study_years
+  )
+  if (!isTRUE(all.equal(
+    as.data.frame(expected_study),
+    as.data.frame(outputs$study),
+    check.attributes = FALSE
+  ))) {
+    stop("Zoopla study candidate must be an unchanged filter of the long-run candidate.", call. = FALSE)
+  }
+
+  long_metadata <- cleaning_metadata(
+    run_stamp, "rentals", "long_run", CONFIG$years,
+    source_row_count, "raw_safeguarded_files", removed_duplicate_count
+  )
+  study_metadata <- cleaning_metadata(
+    run_stamp, "rentals", "study", CONFIG$study_years,
+    source_row_count, "long_run", removed_duplicate_count
+  )
+  write_cleaning_candidate(outputs$long_run, long_run_path, long_metadata)
+  write_cleaning_candidate(outputs$study, study_path, study_metadata)
+  logger::log_info(
+    "Wrote paired Zoopla candidates with run stamp {run_stamp}: long_run={nrow(outputs$long_run)}, study={nrow(outputs$study)}"
+  )
+  invisible(list(
+    long_run_path = long_run_path,
+    study_path = study_path,
+    run_stamp = run_stamp
+  ))
 }
 
 # Main Workflow
@@ -245,7 +502,19 @@ main <- function(refresh_postcodes = FALSE) {
     df_raw <- load_data()
 
     # Clean data
-    df <- clean_zoopla_data(df_raw)
+    df <- clean_zoopla_data(df_raw, CONFIG$years, track_raw_origin = TRUE)
+    dedupe <- deduplicate_zoopla_transactions(df, df_raw)
+    df <- dedupe$data
+    logger::log_info(
+      "Removed {dedupe$removed_count} exact duplicate Zoopla row(s) across {dedupe$duplicate_group_count} group(s) before rental_id assignment."
+    )
+    if (nrow(dedupe$origin_spot_check) > 0L) {
+      logger::log_info(
+        "Raw-origin duplicate spot check: source rows {paste(dedupe$origin_spot_check$.raw_origin_row, collapse = ', ')}; raw rows identical excluding file bookkeeping={dedupe$origin_spot_check$raw_rows_identical[[1]]}."
+      )
+    } else {
+      logger::log_info("Raw-origin duplicate spot check: no duplicate group available.")
+    }
 
     # Build postcode enrichment using the local lookup keyed on postcode only
     postcode_result <- get_local_postcode_data_for_sales(
@@ -253,22 +522,33 @@ main <- function(refresh_postcodes = FALSE) {
       lookup_path = CONFIG$local_postcode_lookup_path
     )
 
-    # Merge postcode attributes and add a stable rental identifier
-    final_data <- left_join(
-      df,
-      postcode_result$postcode_data,
-      by = "postcode"
-    ) %>%
-      mutate(rental_id = row_number()) %>%
-      relocate(rental_id, .before = 1)
-
-    # Export final data
-    export_path <- export_zoopla_data(final_data, CONFIG$canonical_output_path)
-    logger::log_info("Export complete: {export_path}")
+    final_data <- enrich_zoopla_postcodes(df, postcode_result$postcode_data)
+    outputs <- build_zoopla_output_pair(
+      final_data,
+      CONFIG$years,
+      CONFIG$study_years
+    )
+    publication <- write_zoopla_candidates(
+      outputs,
+      run_stamp = new_cleaning_run_stamp(),
+      source_row_count = nrow(df_raw),
+      removed_duplicate_count = dedupe$removed_count
+    )
+    logger::log_info(
+      "Validated unique seven-field rental identity and rental_id hashes across {nrow(outputs$long_run)} long-run rows."
+    )
 
     invisible(
       list(
-        output_path = CONFIG$canonical_output_path,
+        output_paths = publication[c("long_run_path", "study_path")],
+        run_stamp = publication$run_stamp,
+        row_counts = c(
+          long_run = nrow(outputs$long_run),
+          study = nrow(outputs$study)
+        ),
+        dedupe = dedupe[c(
+          "removed_count", "duplicate_group_count", "origin_spot_check"
+        )],
         diagnostics = postcode_result$diagnostics
       )
     )

--- a/scripts/R/04_feature_engineering/site_house_sale_match.R
+++ b/scripts/R/04_feature_engineering/site_house_sale_match.R
@@ -214,7 +214,7 @@ match_house_chunk <- function(houses_sf, spill_sites_sf, spill_lookup, radius_km
 
 house_lookup_schema <- function() {
   arrow::schema(
-    house_id = arrow::int32(),
+    house_id = arrow::utf8(),
     site_id = arrow::int32(),
     distance_m = arrow::float64(),
     distance_km = arrow::float64(),
@@ -224,7 +224,7 @@ house_lookup_schema <- function() {
 
 normalise_house_lookup <- function(data) {
   tibble::tibble(
-    house_id = as.integer(data$house_id),
+    house_id = as.character(data$house_id),
     site_id = as.integer(data$site_id),
     distance_m = as.double(data$distance_m),
     distance_km = as.double(data$distance_km),
@@ -314,11 +314,38 @@ validate_house_stage <- function(stage_path, expected_schema,
   invisible(TRUE)
 }
 
+validate_house_publication <- function(output_path, stage_path, expected_schema,
+                                       expected_rows, expected_row_groups) {
+  if (!file.exists(output_path) || file.exists(stage_path)) {
+    stop(
+      "House lookup promotion did not materialize at the canonical path.",
+      call. = FALSE
+    )
+  }
+  reader <- arrow::ParquetFileReader$create(output_path)
+  if (!identical(reader$GetSchema()$ToString(), expected_schema$ToString()) ||
+      reader$num_rows != expected_rows ||
+      reader$num_row_groups != expected_row_groups) {
+    stop("Published house lookup failed canonical verification.", call. = FALSE)
+  }
+  invisible(TRUE)
+}
+
+settle_house_publication <- function(verify, output_path, stage_path,
+                                     delays = c(10, 20, 30)) {
+  for (delay in delays) {
+    Sys.sleep(delay)
+    verify()
+  }
+  invisible(TRUE)
+}
+
 write_house_lookup <- function(houses_sf, spill_sites_sf, spill_lookup,
                                output_path, radius_km, chunk_size,
                                fail_at = NULL,
                                close_writer = function(writer) writer$Close(),
-                               promote_stage = function(from, to) file.rename(from, to)) {
+                               promote_stage = function(from, to) file.rename(from, to),
+                               settle_publication = settle_house_publication) {
   if (!is.numeric(radius_km) || length(radius_km) != 1L ||
       is.na(radius_km) || radius_km <= 0) {
     stop("radius_km must be one positive number.", call. = FALSE)
@@ -334,11 +361,12 @@ write_house_lookup <- function(houses_sf, spill_sites_sf, spill_lookup,
   output_stream <- NULL
   writer_open <- FALSE
   stream_open <- FALSE
+  preserve_stage <- FALSE
   on.exit(
     {
       if (writer_open) try(writer$Close(), silent = TRUE)
       if (stream_open) try(output_stream$close(), silent = TRUE)
-      unlink(stage_path)
+      if (!preserve_stage) unlink(stage_path)
     },
     add = TRUE
   )
@@ -418,6 +446,26 @@ write_house_lookup <- function(houses_sf, spill_sites_sf, spill_lookup,
   if (!promote_stage(stage_path, output_path)) {
     stop("Failed to promote the staged house lookup.", call. = FALSE)
   }
+  validate_house_publication(
+    output_path,
+    stage_path,
+    expected_schema = schema,
+    expected_rows = output_rows,
+    expected_row_groups = length(starts)
+  )
+  preserve_stage <- TRUE
+  settle_publication(
+    function() validate_house_publication(
+      output_path,
+      stage_path,
+      expected_schema = schema,
+      expected_rows = output_rows,
+      expected_row_groups = length(starts)
+    ),
+    output_path,
+    stage_path
+  )
+  preserve_stage <- FALSE
   logger::log_info(
     "Published {output_rows} house lookup rows across {length(starts)} row groups to {output_path}"
   )
@@ -432,7 +480,8 @@ write_house_lookup <- function(houses_sf, spill_sites_sf, spill_lookup,
 process_spatial_data <- function(data, output_path, radius_km, chunk_size,
                                  fail_at = NULL,
                                  close_writer = function(writer) writer$Close(),
-                                 promote_stage = function(from, to) file.rename(from, to)) {
+                                 promote_stage = function(from, to) file.rename(from, to),
+                                 settle_publication = settle_house_publication) {
   houses_sf <- prepare_house_data(data$house)
   spill_data <- prepare_spill_sites(data$spill)
   write_house_lookup(
@@ -444,7 +493,8 @@ process_spatial_data <- function(data, output_path, radius_km, chunk_size,
     chunk_size = chunk_size,
     fail_at = fail_at,
     close_writer = close_writer,
-    promote_stage = promote_stage
+    promote_stage = promote_stage,
+    settle_publication = settle_publication
   )
 }
 

--- a/scripts/R/04_feature_engineering/site_rental_match.R
+++ b/scripts/R/04_feature_engineering/site_rental_match.R
@@ -218,7 +218,7 @@ match_rental_chunk <- function(rentals_sf, spill_sites_sf, spill_lookup, radius_
 
 rental_lookup_schema <- function() {
   arrow::schema(
-    rental_id = arrow::int32(),
+    rental_id = arrow::utf8(),
     site_id = arrow::int32(),
     distance_m = arrow::float64(),
     distance_km = arrow::float64(),
@@ -228,7 +228,7 @@ rental_lookup_schema <- function() {
 
 normalise_rental_lookup <- function(data) {
   tibble::tibble(
-    rental_id = as.integer(data$rental_id),
+    rental_id = as.character(data$rental_id),
     site_id = as.integer(data$site_id),
     distance_m = as.double(data$distance_m),
     distance_km = as.double(data$distance_km),
@@ -318,11 +318,38 @@ validate_rental_stage <- function(stage_path, expected_schema,
   invisible(TRUE)
 }
 
+validate_rental_publication <- function(output_path, stage_path, expected_schema,
+                                        expected_rows, expected_row_groups) {
+  if (!file.exists(output_path) || file.exists(stage_path)) {
+    stop(
+      "Rental lookup promotion did not materialize at the canonical path.",
+      call. = FALSE
+    )
+  }
+  reader <- arrow::ParquetFileReader$create(output_path)
+  if (!identical(reader$GetSchema()$ToString(), expected_schema$ToString()) ||
+      reader$num_rows != expected_rows ||
+      reader$num_row_groups != expected_row_groups) {
+    stop("Published rental lookup failed canonical verification.", call. = FALSE)
+  }
+  invisible(TRUE)
+}
+
+settle_rental_publication <- function(verify, output_path, stage_path,
+                                      delays = c(10, 20, 30)) {
+  for (delay in delays) {
+    Sys.sleep(delay)
+    verify()
+  }
+  invisible(TRUE)
+}
+
 write_rental_lookup <- function(rentals_sf, spill_sites_sf, spill_lookup,
                                 output_path, radius_km, chunk_size,
                                 fail_at = NULL,
                                 close_writer = function(writer) writer$Close(),
-                                promote_stage = function(from, to) file.rename(from, to)) {
+                                promote_stage = function(from, to) file.rename(from, to),
+                                settle_publication = settle_rental_publication) {
   if (!is.numeric(radius_km) || length(radius_km) != 1L ||
       is.na(radius_km) || radius_km <= 0) {
     stop("radius_km must be one positive number.", call. = FALSE)
@@ -338,11 +365,12 @@ write_rental_lookup <- function(rentals_sf, spill_sites_sf, spill_lookup,
   output_stream <- NULL
   writer_open <- FALSE
   stream_open <- FALSE
+  preserve_stage <- FALSE
   on.exit(
     {
       if (writer_open) try(writer$Close(), silent = TRUE)
       if (stream_open) try(output_stream$close(), silent = TRUE)
-      unlink(stage_path)
+      if (!preserve_stage) unlink(stage_path)
     },
     add = TRUE
   )
@@ -422,6 +450,26 @@ write_rental_lookup <- function(rentals_sf, spill_sites_sf, spill_lookup,
   if (!promote_stage(stage_path, output_path)) {
     stop("Failed to promote the staged rental lookup.", call. = FALSE)
   }
+  validate_rental_publication(
+    output_path,
+    stage_path,
+    expected_schema = schema,
+    expected_rows = output_rows,
+    expected_row_groups = length(starts)
+  )
+  preserve_stage <- TRUE
+  settle_publication(
+    function() validate_rental_publication(
+      output_path,
+      stage_path,
+      expected_schema = schema,
+      expected_rows = output_rows,
+      expected_row_groups = length(starts)
+    ),
+    output_path,
+    stage_path
+  )
+  preserve_stage <- FALSE
   logger::log_info(
     "Published {output_rows} rental lookup rows across {length(starts)} row groups to {output_path}"
   )
@@ -436,7 +484,8 @@ write_rental_lookup <- function(rentals_sf, spill_sites_sf, spill_lookup,
 process_spatial_data <- function(data, output_path, radius_km, chunk_size,
                                  fail_at = NULL,
                                  close_writer = function(writer) writer$Close(),
-                                 promote_stage = function(from, to) file.rename(from, to)) {
+                                 promote_stage = function(from, to) file.rename(from, to),
+                                 settle_publication = settle_rental_publication) {
   rentals_sf <- prepare_rental_data(data$rentals)
   spill_data <- prepare_spill_sites(data$spill)
   write_rental_lookup(
@@ -448,7 +497,8 @@ process_spatial_data <- function(data, output_path, radius_km, chunk_size,
     chunk_size = chunk_size,
     fail_at = fail_at,
     close_writer = close_writer,
-    promote_stage = promote_stage
+    promote_stage = promote_stage,
+    settle_publication = settle_publication
   )
 }
 

--- a/scripts/R/06_analysis_datasets/grid_long_difference_rentals.R
+++ b/scripts/R/06_analysis_datasets/grid_long_difference_rentals.R
@@ -253,7 +253,7 @@ compute_rental_spill_exposure <- function(rental_dt, spill_lookup_dt, agg_spill_
     log_info("Computed spill exposure for {nrow(rental_spill_near)} rental-year pairs with nearby sites")
   } else {
     rental_spill_near <- data.table(
-      rental_id = integer(),
+      rental_id = character(),
       year = integer(),
       spill_count = numeric(),
       spill_hrs = numeric(),

--- a/scripts/R/06_analysis_datasets/grid_long_difference_sales.R
+++ b/scripts/R/06_analysis_datasets/grid_long_difference_sales.R
@@ -83,6 +83,26 @@ CONFIG <- list(
 # Data Loading Functions
 ############################################################
 
+#' Load the house-site lookup within a radius without materialising all rows
+#' @param path Path to the spill lookup parquet dataset
+#' @param radius_m Maximum house-site distance in metres
+#' @param open_dataset_fn Injectable Arrow dataset opener for contract tests
+#' @param collect_fn Injectable collector for contract tests
+#' @return data.table with house_id, site_id, and distance_m
+load_spill_lookup_within_radius <- function(
+  path,
+  radius_m,
+  open_dataset_fn = arrow::open_dataset,
+  collect_fn = dplyr::collect
+) {
+  lookup_query <- open_dataset_fn(path) |>
+    dplyr::select(house_id, site_id, distance_m) |>
+    dplyr::filter(distance_m <= radius_m)
+
+  collect_fn(lookup_query) |>
+    as.data.table()
+}
+
 #' Load all required datasets
 #' @return List containing house_dt, spill_lookup_dt, agg_spill_dt
 load_data <- function() {
@@ -114,9 +134,10 @@ load_data <- function() {
 
   spill_lookup_dt <- tryCatch(
     {
-      dt <- arrow::read_parquet(CONFIG$spill_lookup_path)
-      dt <- as.data.table(dt)
-      dt[distance_m <= CONFIG$spill_radius, .(house_id, site_id, distance_m)]
+      load_spill_lookup_within_radius(
+        CONFIG$spill_lookup_path,
+        CONFIG$spill_radius
+      )
     },
     error = function(e) {
       log_error("Failed to load spill lookup: {e$message}")

--- a/scripts/R/06_analysis_datasets/house_panel_within_radius.R
+++ b/scripts/R/06_analysis_datasets/house_panel_within_radius.R
@@ -12,6 +12,10 @@
 #' specified radius of sites. The final output is a partitioned parquet dataset
 #' containing all sales across all radii.
 
+source(here::here(
+  "scripts", "R", "utils", "duckdb_refresh_utils.R"
+))
+
 # Setup Functions
 ############################################################
 
@@ -69,6 +73,7 @@ connect_to_db <- function() {
   tryCatch(
     {
       con <- DBI::dbConnect(duckdb::duckdb(), dbdir = CONFIG$db_path)
+      configure_duckdb_temp_directory(con, CONFIG$db_path)
       dbExecute(con, "PRAGMA memory_limit='14GB'")
       dbExecute(con, "PRAGMA max_memory='13GB'")
       dbExecute(con, "PRAGMA max_temp_directory_size='500GiB'")
@@ -82,36 +87,23 @@ connect_to_db <- function() {
   )
 }
 
-#' Load house datasets into DuckDB if not already present
+#' Refresh house datasets in DuckDB from current parquet inputs
 #' @param con DuckDB connection
 #' @return NULL
 load_data_to_db <- function(con) {
-  # Check if tables already exist
-  existing_tables <- DBI::dbListTables(con)
+  logger::log_info("Refreshing house price data from parquet")
+  refresh_duckdb_parquet_view(
+    con,
+    "house_price_data",
+    file.path(CONFIG$processed_dir, "house_price.parquet")
+  )
 
-  # House prices
-  if (!"house_price_data" %in% existing_tables) {
-    logger::log_info("Loading house price data")
-    house_price_data <- import(
-      file.path(CONFIG$processed_dir, "house_price.parquet"),
-      trust = TRUE
-    )
-    copy_to(con, house_price_data, "house_price_data", temporary = FALSE)
-    rm(house_price_data)
-    logger::log_info("House price data loaded")
-  }
-
-  # Spill lookup
-  if (!"spill_lookup" %in% existing_tables) {
-    logger::log_info("Loading spill lookup data")
-    spill_lookup <- import(
-      file.path(CONFIG$processed_dir, "spill_house_lookup.parquet"),
-      trust = TRUE
-    )
-    copy_to(con, spill_lookup, "spill_lookup", temporary = FALSE)
-    rm(spill_lookup)
-    logger::log_info("Spill lookup data loaded")
-  }
+  logger::log_info("Refreshing spill lookup data from parquet")
+  refresh_duckdb_parquet_view(
+    con,
+    "spill_lookup",
+    file.path(CONFIG$processed_dir, "spill_house_lookup.parquet")
+  )
 }
 
 #' Prepare base house price and lookup tables with necessary columns
@@ -122,6 +114,7 @@ prepare_tables <- function(con) {
 
   house_tbl <- tbl(con, "house_price_data") %>%
     select(house_id, price, date_of_transfer) %>%
+    mutate(date_of_transfer = sql("CAST(date_of_transfer AS TIMESTAMP)")) %>%
     mutate(
       year = year(date_of_transfer),
       month = month(date_of_transfer),
@@ -260,9 +253,9 @@ export_house_panel <- function(duckdb_panels) {
 ############################################################
 
 #' Main execution function
-#' @param refresh_db Boolean indicating whether to refresh the database tables
+#' @param refresh_db Retained for compatibility; inputs refresh on every run
 #' @return NULL
-main <- function(refresh_db = FALSE) {
+main <- function(refresh_db = TRUE) {
   tryCatch({
     # Setup
     initialise_environment()
@@ -278,17 +271,7 @@ main <- function(refresh_db = FALSE) {
       add = TRUE
     ) # Ensure disconnection even on error
 
-    # Load data
-    if (refresh_db) {
-      log_info("Refresh requested – reloading data")
-      tables <- DBI::dbListTables(con)
-      for (table in c("house_price_data", "spill_lookup")) {
-        if (table %in% tables) {
-          logger::log_info("Dropping table: {table}")
-          DBI::dbRemoveTable(con, table)
-        }
-      }
-    }
+    # Load data. Parquet-backed relations refresh on every run.
     load_data_to_db(con)
 
     # Prepare data tables (lazy references)

--- a/scripts/R/06_analysis_datasets/rental_panel_exp.R
+++ b/scripts/R/06_analysis_datasets/rental_panel_exp.R
@@ -14,6 +14,10 @@
 #' final output is a partitioned parquet dataset stored under
 #' `data/processed/general_panel/rentals`.
 
+source(here::here(
+  "scripts", "R", "utils", "duckdb_refresh_utils.R"
+))
+
 # Setup Functions
 ############################################################
 
@@ -71,6 +75,7 @@ connect_to_db <- function() {
   tryCatch(
     {
       con <- DBI::dbConnect(duckdb::duckdb(), dbdir = CONFIG$db_path)
+      configure_duckdb_temp_directory(con, CONFIG$db_path)
       dbExecute(con, "PRAGMA memory_limit='14GB'")
       dbExecute(con, "PRAGMA max_memory='13GB'")
       dbExecute(con, "PRAGMA max_temp_directory_size='500GiB'")
@@ -84,37 +89,23 @@ connect_to_db <- function() {
   )
 }
 
-#' Load rental datasets into DuckDB if not already present
+#' Refresh rental datasets in DuckDB from current parquet inputs
 #' @param con DuckDB connection
 #' @return NULL
 load_data_to_db <- function(con) {
-  # Check if tables already exist
-  existing_tables <- DBI::dbListTables(con)
+  logger::log_info("Refreshing rental listing data from parquet")
+  refresh_duckdb_parquet_view(
+    con,
+    "rental_data",
+    file.path(CONFIG$processed_dir, "zoopla", "zoopla_rentals.parquet")
+  )
 
-  # Rental listings
-  if (!"rental_data" %in% existing_tables) {
-    logger::log_info("Loading rental listing data")
-    rental_data <- import(
-      file.path(CONFIG$processed_dir, "zoopla", "zoopla_rentals.parquet"),
-      trust = TRUE
-    )
-    copy_to(con, rental_data, "rental_data", temporary = FALSE)
-    rm(rental_data)
-    logger::log_info("Rental listing data loaded")
-  }
-
-  # Spill lookup
-  if (!"rental_spill_lookup" %in% existing_tables) {
-    logger::log_info("Loading rental spill lookup data")
-    spill_lookup <- import(
-      file.path(CONFIG$processed_dir, "zoopla", "spill_rental_lookup.parquet"),
-      trust = TRUE
-    )
-    copy_to(con, spill_lookup, "rental_spill_lookup", temporary = FALSE)
-    rm(spill_lookup)
-    logger::log_info("Rental spill lookup data loaded")
-  }
-
+  logger::log_info("Refreshing rental spill lookup data from parquet")
+  refresh_duckdb_parquet_view(
+    con,
+    "rental_spill_lookup",
+    file.path(CONFIG$processed_dir, "zoopla", "spill_rental_lookup.parquet")
+  )
 }
 
 #' Prepare base rental, lookup, and quarterly spill statistics tables
@@ -243,9 +234,9 @@ export_rental_panel <- function(duckdb_panels) {
 ############################################################
 
 #' Main execution function
-#' @param refresh_db Boolean indicating whether to refresh the database tables
+#' @param refresh_db Retained for compatibility; inputs refresh on every run
 #' @return NULL
-main <- function(refresh_db = FALSE) {
+main <- function(refresh_db = TRUE) {
   tryCatch({
     initialise_environment()
     setup_logging()
@@ -259,18 +250,7 @@ main <- function(refresh_db = FALSE) {
       add = TRUE
     )
 
-    if (refresh_db) {
-      log_info("Refresh requested – reloading data")
-      tables <- DBI::dbListTables(con)
-      for (table in c(
-        "rental_data", "rental_spill_lookup"
-      )) {
-        if (table %in% tables) {
-          logger::log_info("Dropping table: {table}")
-          DBI::dbRemoveTable(con, table)
-        }
-      }
-    }
+    # Parquet-backed relations refresh on every run.
     load_data_to_db(con)
 
     prepared_tables <- prepare_tables(con)

--- a/scripts/R/06_analysis_datasets/rental_panel_within_radius.R
+++ b/scripts/R/06_analysis_datasets/rental_panel_within_radius.R
@@ -12,6 +12,10 @@
 #' specified radius of sites. The final output is a partitioned parquet dataset
 #' containing all listings across all radii.
 
+source(here::here(
+  "scripts", "R", "utils", "duckdb_refresh_utils.R"
+))
+
 # Setup Functions
 ############################################################
 
@@ -69,6 +73,7 @@ connect_to_db <- function() {
   tryCatch(
     {
       con <- DBI::dbConnect(duckdb::duckdb(), dbdir = CONFIG$db_path)
+      configure_duckdb_temp_directory(con, CONFIG$db_path)
       dbExecute(con, "PRAGMA memory_limit='14GB'")
       dbExecute(con, "PRAGMA max_memory='13GB'")
       dbExecute(con, "PRAGMA max_temp_directory_size='500GiB'")
@@ -82,36 +87,23 @@ connect_to_db <- function() {
   )
 }
 
-#' Load rental datasets into DuckDB if not already present
+#' Refresh rental datasets in DuckDB from current parquet inputs
 #' @param con DuckDB connection
 #' @return NULL
 load_data_to_db <- function(con) {
-  # Check if tables already exist
-  existing_tables <- DBI::dbListTables(con)
+  logger::log_info("Refreshing rental listing data from parquet")
+  refresh_duckdb_parquet_view(
+    con,
+    "rental_data",
+    file.path(CONFIG$processed_dir, "zoopla_rentals.parquet")
+  )
 
-  # Rental listings
-  if (!"rental_data" %in% existing_tables) {
-    logger::log_info("Loading rental listing data")
-    rental_data <- import(
-      file.path(CONFIG$processed_dir, "zoopla_rentals.parquet"),
-      trust = TRUE
-    )
-    copy_to(con, rental_data, "rental_data", temporary = FALSE)
-    rm(rental_data)
-    logger::log_info("Rental listing data loaded")
-  }
-
-  # Spill lookup
-  if (!"rental_spill_lookup" %in% existing_tables) {
-    logger::log_info("Loading spill lookup data")
-    spill_lookup <- import(
-      file.path(CONFIG$processed_dir, "spill_rental_lookup.parquet"),
-      trust = TRUE
-    )
-    copy_to(con, spill_lookup, "rental_spill_lookup", temporary = FALSE)
-    rm(spill_lookup)
-    logger::log_info("Spill lookup data loaded")
-  }
+  logger::log_info("Refreshing rental spill lookup data from parquet")
+  refresh_duckdb_parquet_view(
+    con,
+    "rental_spill_lookup",
+    file.path(CONFIG$processed_dir, "spill_rental_lookup.parquet")
+  )
 }
 
 #' Prepare base rental and lookup tables with necessary columns
@@ -122,6 +114,7 @@ prepare_tables <- function(con) {
 
   rental_tbl <- tbl(con, "rental_data") %>%
     select(rental_id, listing_price, rented_est) %>%
+    mutate(rented_est = sql("CAST(rented_est AS TIMESTAMP)")) %>%
     mutate(
       year = year(rented_est),
       month = month(rented_est),
@@ -259,9 +252,9 @@ export_rental_panel <- function(duckdb_panels) {
 ############################################################
 
 #' Main execution function
-#' @param refresh_db Boolean indicating whether to refresh the database tables
+#' @param refresh_db Retained for compatibility; inputs refresh on every run
 #' @return NULL
-main <- function(refresh_db = FALSE) {
+main <- function(refresh_db = TRUE) {
   tryCatch({
     # Setup
     initialise_environment()
@@ -277,17 +270,7 @@ main <- function(refresh_db = FALSE) {
       add = TRUE
     ) # Ensure disconnection even on error
 
-    # Load data
-    if (refresh_db) {
-      log_info("Refresh requested – reloading data")
-      tables <- DBI::dbListTables(con)
-      for (table in c("rental_data", "rental_spill_lookup")) {
-        if (table %in% tables) {
-          logger::log_info("Dropping table: {table}")
-          DBI::dbRemoveTable(con, table)
-        }
-      }
-    }
+    # Load data. Parquet-backed relations refresh on every run.
     load_data_to_db(con)
 
     # Prepare data tables (lazy references)

--- a/scripts/R/06_analysis_datasets/repeat_rentals.R
+++ b/scripts/R/06_analysis_datasets/repeat_rentals.R
@@ -1,345 +1,70 @@
-############################################################
-# Identify Repeat Rental Transactions
-# Project: Sewage
-# Date: 26/12/2025
-# Author: Jacopo Olivieri
-############################################################
+# ==============================================================================
+# Repeat Rentals Mapping
+# ==============================================================================
+#
+# Input:
+#   - data/processed/zoopla/zoopla_rentals_long_run.parquet (2014-2023)
+# Output candidate:
+#   - data/processed/repeated_transactions/repeated_rentals_candidate.parquet
+#
+# repeat_count describes the full long-run window. Window-restricted consumers
+# must regroup after filtering.
+# ==============================================================================
 
-#' This script identifies repeat rental transactions (same property rented
-#' multiple times) using address matching. It creates a unique repeat_id
-#' for each property and generates summary statistics by distance to
-#' sewage spill sites.
-
-# Setup Functions
-############################################################
-
-#' Initialize the R environment with required packages and settings
-#' @return NULL
-initialise_environment <- function() {
-  required_packages <- c(
-    "rio", "here", "logger", "glue", "dplyr", "stringr",
-    "data.table", "arrow"
-  )
-  invisible(sapply(required_packages, function(pkg) {
-    if (!requireNamespace(pkg, quietly = TRUE)) install.packages(pkg)
-    library(pkg, character.only = TRUE)
-  }))
+if (!requireNamespace("here", quietly = TRUE)) {
+  stop("Package `here` is required. Install dependencies with `rv sync`.", call. = FALSE)
 }
 
-#' Set up logging configuration
-#' @return NULL
-setup_logging <- function() {
-  log_path <- here::here("output", "log", "repeat_rentals.log")
-  dir.create(dirname(log_path), recursive = TRUE, showWarnings = FALSE)
-  log_appender(appender_file(log_path))
-  log_layout(layout_glue_colors)
-  log_threshold(INFO)
-  log_info("Script started at {Sys.time()}")
-}
+source(here::here("scripts", "R", "utils", "script_setup.R"), local = TRUE)
 
-# Configuration
-############################################################
-
-CONFIG <- list(
-  input_path = here::here("data", "processed", "zoopla", "zoopla_rentals.parquet"),
-  spill_lookup_path = here::here(
-    "data", "processed", "zoopla", "spill_rental_lookup.parquet"
-  ),
-  output_dir = here::here("data", "processed", "repeated_transactions"),
-  output_path = here::here(
-    "data", "processed", "repeated_transactions", "repeated_rentals.parquet"
-  ),
-  output_summary_path = here::here(
-    "data", "processed", "repeated_transactions", "repeated_rentals_summary.parquet"
-  )
+REQUIRED_PACKAGES <- c(
+  "arrow", "data.table", "digest", "logger", "lubridate", "tidyselect"
 )
+check_required_packages(REQUIRED_PACKAGES)
 
-# Helper Functions
-############################################################
+source(here::here("scripts", "R", "utils", "hash_utils.R"), local = TRUE)
+source(here::here("scripts", "R", "utils", "repeat_transactions_utils.R"), local = TRUE)
 
-#' Basic string cleaning: uppercase, collapse whitespace, convert empty to NA
-#' @param x Character vector
-#' @return Cleaned character vector
-clean_basic <- function(x) {
-  x %>%
-    str_to_upper() %>%
-    str_replace_all("\\s+", " ") %>%
-    str_squish() %>%
-    na_if("")
-}
-
-#' Normalise postcode: uppercase and remove all whitespace
-#' @param x Character vector of postcodes
-#' @return Normalised postcode character vector
-normalise_postcode <- function(x) {
-  x %>%
-    str_to_upper() %>%
-    str_replace_all("\\s+", "") %>%
-    na_if("")
-}
-
-# Data Processing Functions
-############################################################
-
-#' Load rental data from parquet
-#' @return data.table of rental data
-load_data <- function() {
-  log_info("Loading rental data from {CONFIG$input_path}")
-  tryCatch(
-    {
-      dt <- rio::import(CONFIG$input_path, trust = TRUE)
-      dt <- as.data.table(dt)
-      log_info("Loaded {nrow(dt)} rental records")
-      return(dt)
-    },
-    error = function(e) {
-      log_error("Failed to load rental data: {e$message}")
-      stop(e)
-    }
-  )
-}
-
-#' Clean addresses and create matching key
-#' @param dt data.table of rental data
-#' @return data.table with cleaned address columns and simple_key
-clean_addresses <- function(dt) {
-  log_info("Cleaning addresses and creating matching keys")
-
-  dt[, `:=`(
-    rented_est = as.IDate(rented_est),
-    listing_price = as.numeric(listing_price),
-    postcode_clean = normalise_postcode(postcode),
-    address_line_01_clean = clean_basic(address_line_01),
-    address_line_02_clean = clean_basic(address_line_02),
-    address_line_03_clean = clean_basic(address_line_03)
-  )]
-
-  dt[,
-    simple_key := fifelse(
-      !is.na(postcode_clean) & !is.na(address_line_01_clean),
-      paste(
-        postcode_clean, address_line_01_clean,
-        address_line_02_clean, address_line_03_clean,
-        sep = "|"
-      ),
-      NA_character_
-    )
-  ]
-
-  # Remove keys that are effectively all NA
-  dt[grepl("^(NA\\|)*NA$", simple_key), simple_key := NA_character_]
-
-  n_with_key <- dt[!is.na(simple_key), .N]
-  log_info("Created matching keys for {n_with_key} records ({round(100 * n_with_key / nrow(dt), 1)}%)")
-
-  return(dt)
-}
-
-#' Identify repeat transactions and calculate metrics
-#' @param dt data.table with simple_key column
-#' @return data.table with repeat transaction metrics
-identify_repeat_transactions <- function(dt) {
-  log_info("Identifying repeat transactions")
-
-  setorder(dt, simple_key, rented_est, rental_id)
-
-  dt[
-    !is.na(simple_key),
-    `:=`(
-      rental_sequence = seq_len(.N),
-      rental_count = .N,
-      lag_date = shift(rented_est),
-      lag_price = shift(listing_price)
+repeat_rentals_config <- function(output_dir = here::here(
+  "data", "processed", "repeated_transactions"
+)) {
+  list(
+    id_col = "rental_id",
+    date_col = "rented_est",
+    price_col = "listing_price",
+    postcode_col = "postcode",
+    address_cols = c(
+      "postcode", "address_line_01", "address_line_02", "address_line_03"
     ),
-    by = simple_key
-  ]
-
-  dt[
-    !is.na(simple_key),
-    `:=`(
-      holding_period_days = as.numeric(rented_est - lag_date),
-      price_change = listing_price - lag_price,
-      pct_change = fifelse(
-        !is.na(lag_price) & lag_price > 0,
-        listing_price / lag_price - 1,
-        NA_real_
-      )
-    )
-  ]
-
-  n_repeat <- dt[!is.na(simple_key) & rental_count > 1, .N]
-  n_properties_repeat <- dt[!is.na(simple_key) & rental_count > 1, uniqueN(simple_key)]
-  log_info("Found {n_repeat} transactions from {n_properties_repeat} properties with repeat rentals")
-
-  return(dt)
-}
-
-#' Export repeat transaction IDs to parquet
-#' @param dt data.table with repeat transaction data
-#' @return NULL
-export_repeat_ids <- function(dt) {
-  log_info("Exporting repeat transaction IDs")
-
-  dir.create(CONFIG$output_dir, recursive = TRUE, showWarnings = FALSE)
-
-  # Prepare repeated rentals (rental_count > 1)
-  repeat_dt <- dt[!is.na(simple_key) & rental_count > 1]
-  repeat_dt[, repeat_id := .GRP, by = simple_key]
-
-  repeated_output <- repeat_dt[, .(rental_id, repeat_id)]
-
-  # Prepare single rentals (rental_count == 1)
-  max_repeat_id <- max(repeated_output$repeat_id)
-  single_dt <- dt[!is.na(simple_key) & rental_count == 1]
-  single_dt[, repeat_id := max_repeat_id + seq_len(.N)]
-
-  single_output <- single_dt[, .(rental_id, repeat_id)]
-
-  # Combine
-  all_output <- rbindlist(list(repeated_output, single_output))
-
-  tryCatch(
-    {
-      arrow::write_parquet(all_output, CONFIG$output_path)
-      log_info("Exported {nrow(all_output)} records to {CONFIG$output_path}")
-    },
-    error = function(e) {
-      log_error("Failed to export repeat IDs: {e$message}")
-      stop(e)
-    }
-  )
-}
-
-#' Load spill-rental lookup and compute distance flags
-#' @return data.table with distance flags per rental_id
-load_spill_lookup <- function() {
-  log_info("Loading spill-rental lookup from {CONFIG$spill_lookup_path}")
-
-  tryCatch(
-    {
-      spill_lookup <- arrow::open_dataset(CONFIG$spill_lookup_path) |>
-        dplyr::group_by(rental_id) |>
-        dplyr::summarise(distance_m = min(distance_m, na.rm = TRUE)) |>
-        dplyr::collect()
-
-      spill_lookup <- as.data.table(spill_lookup)
-
-      spill_lookup[, `:=`(
-        within_250m = distance_m <= 250,
-        within_500m = distance_m <= 500,
-        within_1000m = distance_m <= 1000,
-        outside_1000m = distance_m > 1000
-      )]
-
-      log_info("Loaded distance data for {nrow(spill_lookup)} properties")
-      return(spill_lookup)
-    },
-    error = function(e) {
-      log_error("Failed to load spill lookup: {e$message}")
-      stop(e)
-    }
-  )
-}
-
-#' Generate summary statistics by rental count and distance
-#' @param spill_lookup data.table with distance flags
-#' @return data.table with summary statistics
-generate_summary <- function(spill_lookup) {
-  log_info("Generating summary statistics")
-
-  # Load the repeat IDs we just exported
-  rentals_dt <- rio::import(CONFIG$output_path, trust = TRUE)
-  rentals_dt <- as.data.table(rentals_dt)
-
-  # Join with spill lookup
-  summary_dt <- rentals_dt[
-    spill_lookup,
-    on = "rental_id",
-    nomatch = NA
-  ][,
-    .(
-      rental_count = .N,
-      within_250m = any(within_250m, na.rm = TRUE),
-      within_500m = any(within_500m, na.rm = TRUE),
-      within_1000m = any(within_1000m, na.rm = TRUE),
-      outside_1000m = any(outside_1000m, na.rm = TRUE)
+    primary_address_col = "address_line_01",
+    property_type_col = "property_type",
+    duplicate_check_cols = c(
+      "postcode", "address_line_01", "address_line_02", "address_line_03",
+      "listing_price", "latest_to_rent", "rented"
     ),
-    by = repeat_id
-  ][,
-    .(
-      n_properties = .N,
-      share_within_250m = mean(within_250m, na.rm = TRUE),
-      share_within_500m = mean(within_500m, na.rm = TRUE),
-      share_within_1000m = mean(within_1000m, na.rm = TRUE),
-      share_outside_1000m = mean(outside_1000m, na.rm = TRUE)
+    input_path = here::here(
+      "data", "processed", "zoopla", "zoopla_rentals_long_run.parquet"
     ),
-    by = rental_count
-  ][,
-    share_properties := n_properties / sum(n_properties)
-  ][
-    order(rental_count)
-  ]
-
-  log_info("Generated summary for {nrow(summary_dt)} rental count categories")
-  return(summary_dt)
-}
-
-#' Export summary statistics to parquet
-#' @param summary_dt data.table with summary statistics
-#' @return NULL
-export_summary <- function(summary_dt) {
-  log_info("Exporting summary statistics")
-
-  tryCatch(
-    {
-      arrow::write_parquet(summary_dt, CONFIG$output_summary_path)
-      log_info("Exported summary to {CONFIG$output_summary_path}")
-    },
-    error = function(e) {
-      log_error("Failed to export summary: {e$message}")
-      stop(e)
-    }
+    log_file = here::here("output", "log", "repeat_rentals.log"),
+    output_path = file.path(output_dir, "repeated_rentals_candidate.parquet"),
+    previous_manifest_path = file.path(output_dir, "repeated_rentals.parquet"),
+    large_group_review_path = file.path(output_dir, "repeated_rentals_large_groups_candidate.parquet"),
+    price_ratio_review_path = file.path(output_dir, "repeated_rentals_price_ratios_candidate.parquet"),
+    market = "rentals",
+    log_name = "repeat_rentals",
+    year_min = 2014L,
+    year_max = 2023L,
+    key_coverage_floor = 0,
+    repeat_share_floor = 0,
+    large_group_size = 12L,
+    extreme_annualized_price_ratio = 4
   )
 }
 
-# Main Execution
-############################################################
-
-#' Main execution function
-#' @return NULL
-main <- function() {
-  initialise_environment()
-  setup_logging()
-
-  tryCatch(
-    {
-      # Load and process rental data
-      rentals_dt <- load_data()
-      rentals_dt <- clean_addresses(rentals_dt)
-      rentals_dt <- identify_repeat_transactions(rentals_dt)
-
-      # Export repeat IDs
-      export_repeat_ids(rentals_dt)
-
-      # Clean up rental data to free memory
-      rm(rentals_dt)
-      gc(full = TRUE)
-
-      # Generate and export summary
-      spill_lookup <- load_spill_lookup()
-      summary_dt <- generate_summary(spill_lookup)
-      export_summary(summary_dt)
-
-      log_info("Script completed successfully at {Sys.time()}")
-    },
-    error = function(e) {
-      log_error("Fatal error: {e$message}")
-      stop(e)
-    }
-  )
+main <- function(config = repeat_rentals_config(), data = NULL) {
+  setup_logging(config$log_file, console = interactive(), threshold = "INFO")
+  logger::log_info("Building repeat-rentals mapping from the long-run superset.")
+  run_repeat_transactions(config, data = data)
 }
 
-# Execute when run directly
-if (sys.nframe() == 0) {
-  main()
-}
+if (sys.nframe() == 0L) main()

--- a/scripts/R/06_analysis_datasets/repeat_rentals.R
+++ b/scripts/R/06_analysis_datasets/repeat_rentals.R
@@ -18,11 +18,15 @@
 #       repeated_rentals_large_groups_candidate.parquet
 #   - data/processed/repeated_transactions/
 #       repeated_rentals_price_ratios_candidate.parquet
+#   - data/processed/repeated_transactions/
+#       repeated_rentals_same_day_candidate.parquet
 #   - output/log/repeat_rentals.log
 #
 # Notes:
 #   - repeat_count describes the full 2014–2023 window.
 #   - Window-restricted consumers must regroup after filtering.
+#   - Rentals sharing an address and a date are data errors: every conflicting
+#     row is excluded from the mapping and routed to the same-day review.
 #   - Candidate outputs are promoted only after validation succeeds.
 # ==============================================================================
 
@@ -87,11 +91,14 @@ repeat_rentals_config <- function(output_dir = here::here(
     previous_manifest_path = file.path(output_dir, "repeated_rentals.parquet"),
     large_group_review_path = file.path(output_dir, "repeated_rentals_large_groups_candidate.parquet"),
     price_ratio_review_path = file.path(output_dir, "repeated_rentals_price_ratios_candidate.parquet"),
+    same_day_review_path = file.path(output_dir, "repeated_rentals_same_day_candidate.parquet"),
     market = "rentals",
     log_name = "repeat_rentals",
     year_min = 2014L,
     year_max = 2023L,
-    # Observed 2026-08-14 baselines: coverage 1.00000000, repeat share 0.74848970.
+    # Observed 2026-08-15 baselines: coverage 1.00000000, repeat share 0.74848970.
+    # Unchanged from 2026-08-14: this market contains no same-day conflicts, so
+    # the same-day exclusion removes nothing and its review file is empty.
     key_coverage_floor = 0.99,
     repeat_share_floor = 0.70,
     large_group_size = 12L,

--- a/scripts/R/06_analysis_datasets/repeat_rentals.R
+++ b/scripts/R/06_analysis_datasets/repeat_rentals.R
@@ -79,10 +79,7 @@ repeat_rentals_config <- function(output_dir = here::here(
     ),
     primary_address_col = "address_line_01",
     property_type_col = "property_type",
-    duplicate_check_cols = c(
-      "postcode", "address_line_01", "address_line_02", "address_line_03",
-      "listing_price", "latest_to_rent", "rented"
-    ),
+    duplicate_check_cols = RENTAL_IDENTITY_FIELDS,
     input_path = here::here(
       "data", "processed", "zoopla", "zoopla_rentals_long_run.parquet"
     ),
@@ -93,7 +90,6 @@ repeat_rentals_config <- function(output_dir = here::here(
     price_ratio_review_path = file.path(output_dir, "repeated_rentals_price_ratios_candidate.parquet"),
     same_day_review_path = file.path(output_dir, "repeated_rentals_same_day_candidate.parquet"),
     market = "rentals",
-    log_name = "repeat_rentals",
     year_min = 2014L,
     year_max = 2023L,
     # Observed 2026-08-15 baselines: coverage 1.00000000, repeat share 0.74848970.

--- a/scripts/R/06_analysis_datasets/repeat_rentals.R
+++ b/scripts/R/06_analysis_datasets/repeat_rentals.R
@@ -2,28 +2,65 @@
 # Repeat Rentals Mapping
 # ==============================================================================
 #
-# Input:
-#   - data/processed/zoopla/zoopla_rentals_long_run.parquet (2014-2023)
-# Output candidate:
-#   - data/processed/repeated_transactions/repeated_rentals_candidate.parquet
+# Purpose: Link rental records at the same address to identify repeat rentals
+#          between 2014–2023.
 #
-# repeat_count describes the full long-run window. Window-restricted consumers
-# must regroup after filtering.
+# Author: Jacopo Olivieri
+# Date: 2026-08-14
+# Date Modified: 2026-08-15
+#
+# Inputs:
+#   - data/processed/zoopla/zoopla_rentals_long_run.parquet (2014–2023)
+#
+# Outputs:
+#   - data/processed/repeated_transactions/repeated_rentals_candidate.parquet
+#   - data/processed/repeated_transactions/
+#       repeated_rentals_large_groups_candidate.parquet
+#   - data/processed/repeated_transactions/
+#       repeated_rentals_price_ratios_candidate.parquet
+#   - output/log/repeat_rentals.log
+#
+# Notes:
+#   - repeat_count describes the full 2014–2023 window.
+#   - Window-restricted consumers must regroup after filtering.
+#   - Candidate outputs are promoted only after validation succeeds.
 # ==============================================================================
 
 if (!requireNamespace("here", quietly = TRUE)) {
-  stop("Package `here` is required. Install dependencies with `rv sync`.", call. = FALSE)
+  stop(
+    "Package `here` is required to run this script. ",
+    "Install project dependencies first with `rv sync`.",
+    call. = FALSE
+  )
 }
 
-source(here::here("scripts", "R", "utils", "script_setup.R"), local = TRUE)
+source(
+  here::here("scripts", "R", "utils", "script_setup.R"),
+  local = TRUE
+)
 
 REQUIRED_PACKAGES <- c(
-  "arrow", "data.table", "digest", "logger", "lubridate", "tidyselect"
+  "arrow",
+  "data.table",
+  "digest",
+  "here",
+  "logger",
+  "lubridate",
+  "tidyselect"
 )
+
+LOG_FILE <- here::here("output", "log", "repeat_rentals.log")
+
 check_required_packages(REQUIRED_PACKAGES)
 
-source(here::here("scripts", "R", "utils", "hash_utils.R"), local = TRUE)
-source(here::here("scripts", "R", "utils", "repeat_transactions_utils.R"), local = TRUE)
+source(
+  here::here("scripts", "R", "utils", "hash_utils.R"),
+  local = TRUE
+)
+source(
+  here::here("scripts", "R", "utils", "repeat_transactions_utils.R"),
+  local = TRUE
+)
 
 repeat_rentals_config <- function(output_dir = here::here(
   "data", "processed", "repeated_transactions"
@@ -45,7 +82,7 @@ repeat_rentals_config <- function(output_dir = here::here(
     input_path = here::here(
       "data", "processed", "zoopla", "zoopla_rentals_long_run.parquet"
     ),
-    log_file = here::here("output", "log", "repeat_rentals.log"),
+    log_file = LOG_FILE,
     output_path = file.path(output_dir, "repeated_rentals_candidate.parquet"),
     previous_manifest_path = file.path(output_dir, "repeated_rentals.parquet"),
     large_group_review_path = file.path(output_dir, "repeated_rentals_large_groups_candidate.parquet"),

--- a/scripts/R/06_analysis_datasets/repeat_rentals.R
+++ b/scripts/R/06_analysis_datasets/repeat_rentals.R
@@ -54,8 +54,9 @@ repeat_rentals_config <- function(output_dir = here::here(
     log_name = "repeat_rentals",
     year_min = 2014L,
     year_max = 2023L,
-    key_coverage_floor = 0,
-    repeat_share_floor = 0,
+    # Observed 2026-08-14 baselines: coverage 1.00000000, repeat share 0.74848970.
+    key_coverage_floor = 0.99,
+    repeat_share_floor = 0.70,
     large_group_size = 12L,
     extreme_annualized_price_ratio = 4
   )

--- a/scripts/R/06_analysis_datasets/repeat_sales.R
+++ b/scripts/R/06_analysis_datasets/repeat_sales.R
@@ -1,340 +1,63 @@
-############################################################
-# Identify Repeat Sales Transactions
-# Project: Sewage
-# Date: 26/12/2025
-# Author: Jacopo Olivieri
-############################################################
+# ==============================================================================
+# Repeat Sales Mapping
+# ==============================================================================
+#
+# Input:
+#   - data/processed/house_price_long_run.parquet (2014-2024)
+# Output candidate:
+#   - data/processed/repeated_transactions/repeated_sales_candidate.parquet
+#
+# repeat_count describes the full long-run window. Window-restricted consumers
+# must regroup after filtering.
+# ==============================================================================
 
-#' This script identifies repeat sales transactions (same property sold
-#' multiple times) using address matching. It creates a unique repeat_id
-#' for each property and generates summary statistics by distance to
-#' sewage spill sites.
-
-# Setup Functions
-############################################################
-
-#' Initialize the R environment with required packages and settings
-#' @return NULL
-initialise_environment <- function() {
-  required_packages <- c(
-    "rio", "here", "logger", "glue", "dplyr", "stringr",
-    "data.table", "arrow"
-  )
-  invisible(sapply(required_packages, function(pkg) {
-    if (!requireNamespace(pkg, quietly = TRUE)) install.packages(pkg)
-    library(pkg, character.only = TRUE)
-  }))
+if (!requireNamespace("here", quietly = TRUE)) {
+  stop("Package `here` is required. Install dependencies with `rv sync`.", call. = FALSE)
 }
 
-#' Set up logging configuration
-#' @return NULL
-setup_logging <- function() {
-  log_path <- here::here("output", "log", "repeat_sales.log")
-  dir.create(dirname(log_path), recursive = TRUE, showWarnings = FALSE)
-  log_appender(appender_file(log_path))
-  log_layout(layout_glue_colors)
-  log_threshold(INFO)
-  log_info("Script started at {Sys.time()}")
-}
+source(here::here("scripts", "R", "utils", "script_setup.R"), local = TRUE)
 
-# Configuration
-############################################################
-
-CONFIG <- list(
-  input_path = here::here("data", "processed", "house_price.parquet"),
-  spill_lookup_path = here::here("data", "processed", "spill_house_lookup.parquet"),
-  output_dir = here::here("data", "processed", "repeated_transactions"),
-  output_path = here::here(
-    "data", "processed", "repeated_transactions", "repeated_sales.parquet"
-  ),
-  output_summary_path = here::here(
-    "data", "processed", "repeated_transactions", "repeated_sales_summary.parquet"
-  )
+REQUIRED_PACKAGES <- c(
+  "arrow", "data.table", "digest", "logger", "lubridate", "tidyselect"
 )
+check_required_packages(REQUIRED_PACKAGES)
 
-# Helper Functions
-############################################################
+source(here::here("scripts", "R", "utils", "hash_utils.R"), local = TRUE)
+source(here::here("scripts", "R", "utils", "repeat_transactions_utils.R"), local = TRUE)
 
-#' Basic string cleaning: uppercase, collapse whitespace, convert empty to NA
-#' @param x Character vector
-#' @return Cleaned character vector
-clean_basic <- function(x) {
-  x %>%
-    str_to_upper() %>%
-    str_replace_all("\\s+", " ") %>%
-    str_squish() %>%
-    na_if("")
-}
-
-#' Normalise postcode: uppercase and remove all whitespace
-#' @param x Character vector of postcodes
-#' @return Normalised postcode character vector
-normalise_postcode <- function(x) {
-  x %>%
-    str_to_upper() %>%
-    str_replace_all("\\s+", "") %>%
-    na_if("")
-}
-
-# Data Processing Functions
-############################################################
-
-#' Load house price data from parquet
-#' @return data.table of sales data
-load_data <- function() {
-  log_info("Loading sales data from {CONFIG$input_path}")
-  tryCatch(
-    {
-      dt <- rio::import(CONFIG$input_path, trust = TRUE)
-      dt <- as.data.table(dt)
-      log_info("Loaded {nrow(dt)} sales records")
-      return(dt)
-    },
-    error = function(e) {
-      log_error("Failed to load sales data: {e$message}")
-      stop(e)
-    }
+repeat_sales_config <- function(output_dir = here::here(
+  "data", "processed", "repeated_transactions"
+)) {
+  list(
+    id_col = "house_id",
+    date_col = "date_of_transfer",
+    price_col = "price",
+    postcode_col = "postcode",
+    address_cols = c("postcode", "paon", "saon", "street"),
+    primary_address_col = "paon",
+    property_type_col = "property_type",
+    duplicate_check_cols = character(),
+    input_path = here::here("data", "processed", "house_price_long_run.parquet"),
+    log_file = here::here("output", "log", "repeat_sales.log"),
+    output_path = file.path(output_dir, "repeated_sales_candidate.parquet"),
+    previous_manifest_path = file.path(output_dir, "repeated_sales.parquet"),
+    large_group_review_path = file.path(output_dir, "repeated_sales_large_groups_candidate.parquet"),
+    price_ratio_review_path = file.path(output_dir, "repeated_sales_price_ratios_candidate.parquet"),
+    market = "sales",
+    log_name = "repeat_sales",
+    year_min = 2014L,
+    year_max = 2024L,
+    key_coverage_floor = 0,
+    repeat_share_floor = 0,
+    large_group_size = 12L,
+    extreme_annualized_price_ratio = 4
   )
 }
 
-#' Clean addresses and create matching key
-#' @param dt data.table of sales data
-#' @return data.table with cleaned address columns and simple_key
-clean_addresses <- function(dt) {
-  log_info("Cleaning addresses and creating matching keys")
-
-  dt[, `:=`(
-    date_of_transfer = as.IDate(date_of_transfer),
-    price = as.numeric(price),
-    postcode_clean = normalise_postcode(postcode),
-    paon_clean = clean_basic(paon),
-    saon_clean = clean_basic(saon),
-    street_clean = clean_basic(street)
-  )]
-
-  dt[,
-    simple_key := fifelse(
-      !is.na(postcode_clean) & !is.na(paon_clean),
-      paste(postcode_clean, paon_clean, saon_clean, street_clean, sep = "|"),
-      NA_character_
-    )
-  ]
-
-  # Remove keys that are effectively all NA
-
-dt[grepl("^(NA\\|)*NA$", simple_key), simple_key := NA_character_]
-
-  n_with_key <- dt[!is.na(simple_key), .N]
-  log_info("Created matching keys for {n_with_key} records ({round(100 * n_with_key / nrow(dt), 1)}%)")
-
-  return(dt)
+main <- function(config = repeat_sales_config(), data = NULL) {
+  setup_logging(config$log_file, console = interactive(), threshold = "INFO")
+  logger::log_info("Building repeat-sales mapping from the long-run superset.")
+  run_repeat_transactions(config, data = data)
 }
 
-#' Identify repeat transactions and calculate metrics
-#' @param dt data.table with simple_key column
-#' @return data.table with repeat transaction metrics
-identify_repeat_transactions <- function(dt) {
-  log_info("Identifying repeat transactions")
-
-  setorder(dt, simple_key, date_of_transfer, transaction_id)
-
-  dt[
-    !is.na(simple_key),
-    `:=`(
-      sale_sequence = seq_len(.N),
-      sale_count = .N,
-      lag_date = shift(date_of_transfer),
-      lag_price = shift(price)
-    ),
-    by = simple_key
-  ]
-
-  dt[
-    !is.na(simple_key),
-    `:=`(
-      holding_period_days = as.numeric(date_of_transfer - lag_date),
-      price_change = price - lag_price,
-      pct_change = fifelse(
-        !is.na(lag_price) & lag_price > 0,
-        price / lag_price - 1,
-        NA_real_
-      )
-    )
-  ]
-
-  n_repeat <- dt[!is.na(simple_key) & sale_count > 1, .N]
-  n_properties_repeat <- dt[!is.na(simple_key) & sale_count > 1, uniqueN(simple_key)]
-  log_info("Found {n_repeat} transactions from {n_properties_repeat} properties with repeat sales")
-
-  return(dt)
-}
-
-#' Export repeat transaction IDs to parquet
-#' @param dt data.table with repeat transaction data
-#' @return NULL
-export_repeat_ids <- function(dt) {
-  log_info("Exporting repeat transaction IDs")
-
-  dir.create(CONFIG$output_dir, recursive = TRUE, showWarnings = FALSE)
-
-  # Prepare repeated sales (sale_count > 1)
-  repeat_dt <- dt[!is.na(simple_key) & sale_count > 1]
-  repeat_dt[, repeat_id := .GRP, by = simple_key]
-
-  repeated_output <- repeat_dt[, .(house_id, repeat_id)]
-
-  # Prepare single sales (sale_count == 1)
-  max_repeat_id <- max(repeated_output$repeat_id)
-  single_dt <- dt[!is.na(simple_key) & sale_count == 1]
-  single_dt[, repeat_id := max_repeat_id + seq_len(.N)]
-
-  single_output <- single_dt[, .(house_id, repeat_id)]
-
-  # Combine
-  all_output <- rbindlist(list(repeated_output, single_output))
-
-  tryCatch(
-    {
-      arrow::write_parquet(all_output, CONFIG$output_path)
-      log_info("Exported {nrow(all_output)} records to {CONFIG$output_path}")
-    },
-    error = function(e) {
-      log_error("Failed to export repeat IDs: {e$message}")
-      stop(e)
-    }
-  )
-}
-
-#' Load spill-house lookup and compute distance flags
-#' @return data.table with distance flags per house_id
-load_spill_lookup <- function() {
-  log_info("Loading spill-house lookup from {CONFIG$spill_lookup_path}")
-
-  tryCatch(
-    {
-      spill_lookup <- arrow::open_dataset(CONFIG$spill_lookup_path) |>
-        dplyr::group_by(house_id) |>
-        dplyr::summarise(distance_m = min(distance_m, na.rm = TRUE)) |>
-        dplyr::collect()
-
-      spill_lookup <- as.data.table(spill_lookup)
-
-      spill_lookup[, `:=`(
-        within_250m = distance_m <= 250,
-        within_500m = distance_m <= 500,
-        within_1000m = distance_m <= 1000,
-        outside_1000m = distance_m > 1000
-      )]
-
-      log_info("Loaded distance data for {nrow(spill_lookup)} properties")
-      return(spill_lookup)
-    },
-    error = function(e) {
-      log_error("Failed to load spill lookup: {e$message}")
-      stop(e)
-    }
-  )
-}
-
-#' Generate summary statistics by sale count and distance
-#' @param spill_lookup data.table with distance flags
-#' @return data.table with summary statistics
-generate_summary <- function(spill_lookup) {
-  log_info("Generating summary statistics")
-
-  # Load the repeat IDs we just exported
-  sales_dt <- rio::import(CONFIG$output_path, trust = TRUE)
-  sales_dt <- as.data.table(sales_dt)
-
-  # Join with spill lookup
-  summary_dt <- sales_dt[
-    spill_lookup,
-    on = "house_id",
-    nomatch = NA
-  ][,
-    .(
-      sale_count = .N,
-      within_250m = any(within_250m, na.rm = TRUE),
-      within_500m = any(within_500m, na.rm = TRUE),
-      within_1000m = any(within_1000m, na.rm = TRUE),
-      outside_1000m = any(outside_1000m, na.rm = TRUE)
-    ),
-    by = repeat_id
-  ][,
-    .(
-      n_properties = .N,
-      share_within_250m = mean(within_250m, na.rm = TRUE),
-      share_within_500m = mean(within_500m, na.rm = TRUE),
-      share_within_1000m = mean(within_1000m, na.rm = TRUE),
-      share_outside_1000m = mean(outside_1000m, na.rm = TRUE)
-    ),
-    by = sale_count
-  ][,
-    share_properties := n_properties / sum(n_properties)
-  ][
-    order(sale_count)
-  ]
-
-  log_info("Generated summary for {nrow(summary_dt)} sale count categories")
-  return(summary_dt)
-}
-
-#' Export summary statistics to parquet
-#' @param summary_dt data.table with summary statistics
-#' @return NULL
-export_summary <- function(summary_dt) {
-  log_info("Exporting summary statistics")
-
-  tryCatch(
-    {
-      arrow::write_parquet(summary_dt, CONFIG$output_summary_path)
-      log_info("Exported summary to {CONFIG$output_summary_path}")
-    },
-    error = function(e) {
-      log_error("Failed to export summary: {e$message}")
-      stop(e)
-    }
-  )
-}
-
-# Main Execution
-############################################################
-
-#' Main execution function
-#' @return NULL
-main <- function() {
-  initialise_environment()
-  setup_logging()
-
-  tryCatch(
-    {
-      # Load and process sales data
-      sales_dt <- load_data()
-      sales_dt <- clean_addresses(sales_dt)
-      sales_dt <- identify_repeat_transactions(sales_dt)
-
-      # Export repeat IDs
-      export_repeat_ids(sales_dt)
-
-      # Clean up sales data to free memory
-      rm(sales_dt)
-      gc(full = TRUE)
-
-      # Generate and export summary
-      spill_lookup <- load_spill_lookup()
-      summary_dt <- generate_summary(spill_lookup)
-      export_summary(summary_dt)
-
-      log_info("Script completed successfully at {Sys.time()}")
-    },
-    error = function(e) {
-      log_error("Fatal error: {e$message}")
-      stop(e)
-    }
-  )
-}
-
-# Execute when run directly
-if (sys.nframe() == 0) {
-  main()
-}
+if (sys.nframe() == 0L) main()

--- a/scripts/R/06_analysis_datasets/repeat_sales.R
+++ b/scripts/R/06_analysis_datasets/repeat_sales.R
@@ -18,11 +18,15 @@
 #       repeated_sales_large_groups_candidate.parquet
 #   - data/processed/repeated_transactions/
 #       repeated_sales_price_ratios_candidate.parquet
+#   - data/processed/repeated_transactions/
+#       repeated_sales_same_day_candidate.parquet
 #   - output/log/repeat_sales.log
 #
 # Notes:
 #   - repeat_count describes the full 2014–2024 window.
 #   - Window-restricted consumers must regroup after filtering.
+#   - Sales sharing an address and a date are data errors: every conflicting row
+#     is excluded from the mapping and routed to the same-day review.
 #   - Candidate outputs are promoted only after validation succeeds.
 # ==============================================================================
 
@@ -80,11 +84,15 @@ repeat_sales_config <- function(output_dir = here::here(
     previous_manifest_path = file.path(output_dir, "repeated_sales.parquet"),
     large_group_review_path = file.path(output_dir, "repeated_sales_large_groups_candidate.parquet"),
     price_ratio_review_path = file.path(output_dir, "repeated_sales_price_ratios_candidate.parquet"),
+    same_day_review_path = file.path(output_dir, "repeated_sales_same_day_candidate.parquet"),
     market = "sales",
     log_name = "repeat_sales",
     year_min = 2014L,
     year_max = 2024L,
-    # Observed 2026-08-14 baselines: coverage 0.99681926, repeat share 0.36939131.
+    # Observed 2026-08-15 baselines: coverage 0.99681926, repeat share 0.36233545.
+    # Coverage measures address-key completeness only and is unchanged from
+    # 2026-08-14. Repeat share fell from 0.36939131 because the 102699 rows in
+    # 50327 same-day conflicts now leave the mapping; largest group fell 20 -> 11.
     key_coverage_floor = 0.99,
     repeat_share_floor = 0.35,
     large_group_size = 12L,

--- a/scripts/R/06_analysis_datasets/repeat_sales.R
+++ b/scripts/R/06_analysis_datasets/repeat_sales.R
@@ -47,8 +47,9 @@ repeat_sales_config <- function(output_dir = here::here(
     log_name = "repeat_sales",
     year_min = 2014L,
     year_max = 2024L,
-    key_coverage_floor = 0,
-    repeat_share_floor = 0,
+    # Observed 2026-08-14 baselines: coverage 0.99681926, repeat share 0.36939131.
+    key_coverage_floor = 0.99,
+    repeat_share_floor = 0.35,
     large_group_size = 12L,
     extreme_annualized_price_ratio = 4
   )

--- a/scripts/R/06_analysis_datasets/repeat_sales.R
+++ b/scripts/R/06_analysis_datasets/repeat_sales.R
@@ -86,7 +86,6 @@ repeat_sales_config <- function(output_dir = here::here(
     price_ratio_review_path = file.path(output_dir, "repeated_sales_price_ratios_candidate.parquet"),
     same_day_review_path = file.path(output_dir, "repeated_sales_same_day_candidate.parquet"),
     market = "sales",
-    log_name = "repeat_sales",
     year_min = 2014L,
     year_max = 2024L,
     # Observed 2026-08-15 baselines: coverage 0.99681926, repeat share 0.36233545.

--- a/scripts/R/06_analysis_datasets/repeat_sales.R
+++ b/scripts/R/06_analysis_datasets/repeat_sales.R
@@ -2,28 +2,65 @@
 # Repeat Sales Mapping
 # ==============================================================================
 #
-# Input:
-#   - data/processed/house_price_long_run.parquet (2014-2024)
-# Output candidate:
-#   - data/processed/repeated_transactions/repeated_sales_candidate.parquet
+# Purpose: Link sales made at the same address to identify repeat sales between
+#          2014–2024.
 #
-# repeat_count describes the full long-run window. Window-restricted consumers
-# must regroup after filtering.
+# Author: Jacopo Olivieri
+# Date: 2026-08-14
+# Date Modified: 2026-08-15
+#
+# Inputs:
+#   - data/processed/house_price_long_run.parquet (2014–2024)
+#
+# Outputs:
+#   - data/processed/repeated_transactions/repeated_sales_candidate.parquet
+#   - data/processed/repeated_transactions/
+#       repeated_sales_large_groups_candidate.parquet
+#   - data/processed/repeated_transactions/
+#       repeated_sales_price_ratios_candidate.parquet
+#   - output/log/repeat_sales.log
+#
+# Notes:
+#   - repeat_count describes the full 2014–2024 window.
+#   - Window-restricted consumers must regroup after filtering.
+#   - Candidate outputs are promoted only after validation succeeds.
 # ==============================================================================
 
 if (!requireNamespace("here", quietly = TRUE)) {
-  stop("Package `here` is required. Install dependencies with `rv sync`.", call. = FALSE)
+  stop(
+    "Package `here` is required to run this script. ",
+    "Install project dependencies first with `rv sync`.",
+    call. = FALSE
+  )
 }
 
-source(here::here("scripts", "R", "utils", "script_setup.R"), local = TRUE)
+source(
+  here::here("scripts", "R", "utils", "script_setup.R"),
+  local = TRUE
+)
 
 REQUIRED_PACKAGES <- c(
-  "arrow", "data.table", "digest", "logger", "lubridate", "tidyselect"
+  "arrow",
+  "data.table",
+  "digest",
+  "here",
+  "logger",
+  "lubridate",
+  "tidyselect"
 )
+
+LOG_FILE <- here::here("output", "log", "repeat_sales.log")
+
 check_required_packages(REQUIRED_PACKAGES)
 
-source(here::here("scripts", "R", "utils", "hash_utils.R"), local = TRUE)
-source(here::here("scripts", "R", "utils", "repeat_transactions_utils.R"), local = TRUE)
+source(
+  here::here("scripts", "R", "utils", "hash_utils.R"),
+  local = TRUE
+)
+source(
+  here::here("scripts", "R", "utils", "repeat_transactions_utils.R"),
+  local = TRUE
+)
 
 repeat_sales_config <- function(output_dir = here::here(
   "data", "processed", "repeated_transactions"
@@ -38,7 +75,7 @@ repeat_sales_config <- function(output_dir = here::here(
     property_type_col = "property_type",
     duplicate_check_cols = character(),
     input_path = here::here("data", "processed", "house_price_long_run.parquet"),
-    log_file = here::here("output", "log", "repeat_sales.log"),
+    log_file = LOG_FILE,
     output_path = file.path(output_dir, "repeated_sales_candidate.parquet"),
     previous_manifest_path = file.path(output_dir, "repeated_sales.parquet"),
     large_group_review_path = file.path(output_dir, "repeated_sales_large_groups_candidate.parquet"),

--- a/scripts/R/06_analysis_datasets/sale_panel_exp.R
+++ b/scripts/R/06_analysis_datasets/sale_panel_exp.R
@@ -13,6 +13,10 @@
 #' that will require further processing depending on the specific analysis requirements.
 #' The final output is a partitioned parquet dataset.
 
+source(here::here(
+  "scripts", "R", "utils", "duckdb_refresh_utils.R"
+))
+
 # Setup Functions
 ############################################################
 
@@ -70,6 +74,7 @@ connect_to_db <- function() {
   tryCatch(
     {
       con <- DBI::dbConnect(duckdb::duckdb(), dbdir = CONFIG$db_path)
+      configure_duckdb_temp_directory(con, CONFIG$db_path)
       dbExecute(con, "PRAGMA memory_limit='14GB'")
       dbExecute(con, "PRAGMA max_memory='13GB'")
       dbExecute(con, "PRAGMA max_temp_directory_size='500GiB'")
@@ -83,37 +88,23 @@ connect_to_db <- function() {
   )
 }
 
-#' Load house datasets into DuckDB if not already present
+#' Refresh house datasets in DuckDB from current parquet inputs
 #' @param con DuckDB connection
 #' @return NULL
 load_data_to_db <- function(con) {
-  # Check if tables already exist
-  existing_tables <- DBI::dbListTables(con)
+  logger::log_info("Refreshing house price data from parquet")
+  refresh_duckdb_parquet_view(
+    con,
+    "house_price_data",
+    file.path(CONFIG$processed_dir, "house_price.parquet")
+  )
 
-  # House prices
-  if (!"house_price_data" %in% existing_tables) {
-    logger::log_info("Loading house price data")
-    house_price_data <- import(
-      file.path(CONFIG$processed_dir, "house_price.parquet"),
-      trust = TRUE
-    )
-    copy_to(con, house_price_data, "house_price_data", temporary = FALSE)
-    rm(house_price_data)
-    logger::log_info("House price data loaded")
-  }
-
-  # Spill lookup
-  if (!"spill_lookup" %in% existing_tables) {
-    logger::log_info("Loading spill lookup data")
-    spill_lookup <- import(
-      file.path(CONFIG$processed_dir, "spill_house_lookup.parquet"),
-      trust = TRUE
-    )
-    copy_to(con, spill_lookup, "spill_lookup", temporary = FALSE)
-    rm(spill_lookup)
-    logger::log_info("Spill lookup data loaded")
-  }
-
+  logger::log_info("Refreshing spill lookup data from parquet")
+  refresh_duckdb_parquet_view(
+    con,
+    "spill_lookup",
+    file.path(CONFIG$processed_dir, "spill_house_lookup.parquet")
+  )
 }
 
 #' Prepare base house price, lookup, and quarterly spill statistics tables
@@ -259,9 +250,9 @@ export_house_panel <- function(duckdb_panels) {
 ############################################################
 
 #' Main execution function
-#' @param refresh_db Boolean indicating whether to refresh the database tables
+#' @param refresh_db Retained for compatibility; inputs refresh on every run
 #' @return NULL
-main <- function(refresh_db = FALSE) {
+main <- function(refresh_db = TRUE) {
   tryCatch({
     # Setup
     initialise_environment()
@@ -277,19 +268,7 @@ main <- function(refresh_db = FALSE) {
       add = TRUE
     )
 
-    # Load data
-    if (refresh_db) {
-      log_info("Refresh requested - reloading data")
-      tables <- DBI::dbListTables(con)
-      for (table in c(
-        "house_price_data", "spill_lookup"
-      )) {
-        if (table %in% tables) {
-          logger::log_info("Dropping table: {table}")
-          DBI::dbRemoveTable(con, table)
-        }
-      }
-    }
+    # Load data. Parquet-backed relations refresh on every run.
     load_data_to_db(con)
 
     # Prepare data tables (lazy references)

--- a/scripts/R/09_analysis/02_hedonic/hedonic_bins_full.R
+++ b/scripts/R/09_analysis/02_hedonic/hedonic_bins_full.R
@@ -125,7 +125,6 @@ gen_panel_sales <- arrow::open_dataset(path_general_panel_sales) |>
 sales <- import(path_sales, trust = TRUE) |>
   mutate(year = (qtr_id - 1) %/% 4 + 1) |>
   select(
-    -transaction_id,
     -date_of_transfer,
     -quality,
     -paon,

--- a/scripts/R/09_analysis/02_hedonic/hedonic_bins_prior.R
+++ b/scripts/R/09_analysis/02_hedonic/hedonic_bins_prior.R
@@ -96,7 +96,6 @@ sales <- import(
   trust = TRUE
 ) |>
   select(
-    -transaction_id,
     -date_of_transfer,
     -quality,
     -paon,

--- a/scripts/R/09_analysis/02_hedonic/hedonic_continuous_full.R
+++ b/scripts/R/09_analysis/02_hedonic/hedonic_continuous_full.R
@@ -114,7 +114,6 @@ gen_panel_sales <- arrow::open_dataset(path_general_panel_sales) |>
 sales <- import(path_sales, trust = TRUE) |>
   mutate(year = (qtr_id - 1) %/% 4 + 1) |>
   select(
-    -transaction_id,
     -date_of_transfer,
     -quality,
     -paon,

--- a/scripts/R/09_analysis/02_hedonic/hedonic_continuous_prior.R
+++ b/scripts/R/09_analysis/02_hedonic/hedonic_continuous_prior.R
@@ -79,7 +79,6 @@ sales <- import(
   trust = TRUE
 ) |>
   select(
-    -transaction_id,
     -date_of_transfer,
     -quality,
     -paon,

--- a/scripts/R/09_analysis/02_hedonic/hedonic_continuous_prior_qtr_fe.R
+++ b/scripts/R/09_analysis/02_hedonic/hedonic_continuous_prior_qtr_fe.R
@@ -79,7 +79,6 @@ sales <- import(
   trust = TRUE
 ) |>
   select(
-    -transaction_id,
     -date_of_transfer,
     -quality,
     -paon,

--- a/scripts/R/09_analysis/03_repeat_sales/repeat_sales.R
+++ b/scripts/R/09_analysis/03_repeat_sales/repeat_sales.R
@@ -92,7 +92,7 @@ house_prices <- import(
   here::here("data", "processed", "house_price.parquet"),
   trust = TRUE
 ) |>
-  select(house_id, transaction_id, price, qtr_id, latitude, longitude)
+  select(house_id, price, qtr_id, latitude, longitude)
 
 # Join and filter to repeat sales only (repeat_id appears 2+ times)
 repeat_sales <- repeat_ids |>
@@ -195,7 +195,7 @@ cat(sprintf("  %d repeat-sale transactions are within %dm of spill sites\n",
 dat_panel <- houses_near_sites |>
   inner_join(spill_lookup, by = "house_id", relationship = "many-to-many") |>
   inner_join(agg_spill_clean, by = c("site_id", "qtr_id")) |>
-  group_by(house_id, transaction_id, repeat_id, qtr_id, price, latitude, longitude) |>
+  group_by(house_id, repeat_id, qtr_id, price, latitude, longitude) |>
   summarise(
     spill_count_roll = sum(spill_count_roll, na.rm = TRUE),
     spill_hrs_roll = sum(spill_hrs_roll, na.rm = TRUE),

--- a/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_decay_binary_did.R
+++ b/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_decay_binary_did.R
@@ -113,7 +113,6 @@ sales <- import(
   trust = TRUE
 ) |>
   select(
-    -transaction_id,
     -date_of_transfer,
     -quality,
     -paon,

--- a/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_decay_ring_triple.R
+++ b/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_decay_ring_triple.R
@@ -155,7 +155,7 @@ sales <- import(
   trust = TRUE
 ) |>
   select(
-    -transaction_id, -date_of_transfer, -quality, -paon, -saon, -street,
+    -date_of_transfer, -quality, -paon, -saon, -street,
     -locality, -town_city, -district, -county, -ppd_category, -record_status
   ) |>
   mutate(

--- a/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_full_all_radii.R
+++ b/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_full_all_radii.R
@@ -95,7 +95,6 @@ sales <- import(
   trust = TRUE
 ) |>
   select(
-    -transaction_id,
     -date_of_transfer,
     -quality,
     -paon,

--- a/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_nearest_all_radii.R
+++ b/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_nearest_all_radii.R
@@ -88,7 +88,6 @@ sales <- import(
   trust = TRUE
 ) |>
   select(
-    -transaction_id,
     -date_of_transfer,
     -quality,
     -paon,

--- a/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_nearest_by_bin.R
+++ b/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_nearest_by_bin.R
@@ -162,7 +162,6 @@ sales <- import(
   trust = TRUE
 ) |>
   select(
-    -transaction_id,
     -date_of_transfer,
     -quality,
     -paon,

--- a/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_nearest_vary_lateral.R
+++ b/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_nearest_vary_lateral.R
@@ -88,7 +88,7 @@ sales <- import(
   trust = TRUE
 ) |>
   select(
-    -transaction_id, -date_of_transfer, -quality, -paon, -saon, -street,
+    -date_of_transfer, -quality, -paon, -saon, -street,
     -locality, -town_city, -district, -county, -ppd_category, -record_status
   ) |>
   mutate(

--- a/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_nearest_vary_river.R
+++ b/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_nearest_vary_river.R
@@ -88,7 +88,7 @@ sales <- import(
   trust = TRUE
 ) |>
   select(
-    -transaction_id, -date_of_transfer, -quality, -paon, -saon, -street,
+    -date_of_transfer, -quality, -paon, -saon, -street,
     -locality, -town_city, -district, -county, -ppd_category, -record_status
   ) |>
   mutate(

--- a/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_only_site_all_radii.R
+++ b/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_only_site_all_radii.R
@@ -89,7 +89,6 @@ sales <- import(
   trust = TRUE
 ) |>
   select(
-    -transaction_id,
     -date_of_transfer,
     -quality,
     -paon,

--- a/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_prior.R
+++ b/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_prior.R
@@ -96,7 +96,6 @@ sales <- import(
   trust = TRUE
 ) |>
   select(
-    -transaction_id,
     -date_of_transfer,
     -quality,
     -paon,

--- a/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_prior_full.R
+++ b/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_prior_full.R
@@ -96,7 +96,6 @@ sales <- import(
   trust = TRUE
 ) |>
   select(
-    -transaction_id,
     -date_of_transfer,
     -quality,
     -paon,

--- a/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_prior_nearest_site.R
+++ b/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_prior_nearest_site.R
@@ -98,7 +98,6 @@ sales <- import(
   trust = TRUE
 ) |>
   select(
-    -transaction_id,
     -date_of_transfer,
     -quality,
     -paon,

--- a/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_prior_only_site.R
+++ b/scripts/R/09_analysis/06_upstream_downstream/upstream_downstream_prior_only_site.R
@@ -96,7 +96,6 @@ sales <- import(
   trust = TRUE
 ) |>
   select(
-    -transaction_id,
     -date_of_transfer,
     -quality,
     -paon,

--- a/scripts/R/testing/reconcile_cleaning_rebuild.R
+++ b/scripts/R/testing/reconcile_cleaning_rebuild.R
@@ -3,9 +3,8 @@
 # ==============================================================================
 #
 # Purpose: Produce non-mutating gate evidence for cleaning rebuild candidates.
-#          This U2 slice covers Land Registry old-versus-new allowed deltas,
-#          duplicate historical transaction IDs, paired-candidate metadata,
-#          and raw/input file checksums. U3 extends the same script for rentals.
+#          Covers Land Registry and Zoopla old-versus-new allowed deltas,
+#          paired-candidate metadata, and source/candidate checksums.
 #
 # This script never promotes, replaces, archives, or deletes canonical data.
 #
@@ -24,6 +23,7 @@ LR_STABLE_EXCLUDED_COLUMNS <- c(
   "qtr_id",
   "month_id"
 )
+ZOOPLA_STABLE_EXCLUDED_COLUMNS <- c("rental_id")
 
 empty_delta_table <- function() {
   tibble::tibble(
@@ -301,6 +301,238 @@ reconcile_lr_allowed_deltas <- function(
   )
 }
 
+zoopla_candidate_period_issues <- function(candidate_long, base_year = 2021L) {
+  expected_qtr <- (lubridate::year(candidate_long$rented_est) - base_year) * 4L +
+    lubridate::quarter(candidate_long$rented_est)
+  expected_month <- (lubridate::year(candidate_long$rented_est) - base_year) * 12L +
+    lubridate::month(candidate_long$rented_est)
+  bad <- is.na(candidate_long$rented_est) |
+    is.na(candidate_long$qtr_id) |
+    is.na(candidate_long$month_id) |
+    candidate_long$qtr_id != expected_qtr |
+    candidate_long$month_id != expected_month
+
+  tibble::tibble(
+    rental_id = candidate_long$rental_id[bad],
+    rented_est = candidate_long$rented_est[bad],
+    qtr_id = candidate_long$qtr_id[bad],
+    expected_qtr_id = expected_qtr[bad],
+    month_id = candidate_long$month_id[bad],
+    expected_month_id = expected_month[bad]
+  )
+}
+
+zoopla_candidate_pair_issues <- function(candidate_long, candidate_study, study_years) {
+  expected <- candidate_long[
+    lubridate::year(candidate_long$rented_est) %in% study_years,
+    ,
+    drop = FALSE
+  ]
+  expected <- expected[order(expected$rental_id), , drop = FALSE]
+  observed <- candidate_study[order(candidate_study$rental_id), , drop = FALSE]
+  same_schema <- identical(names(expected), names(observed))
+  same_rows <- same_schema && isTRUE(all.equal(
+    as.data.frame(expected),
+    as.data.frame(observed),
+    check.attributes = FALSE
+  ))
+
+  tibble::tibble(
+    check = c("study_schema_equals_filtered_long_run", "study_rows_equal_filtered_long_run"),
+    passed = c(same_schema, same_rows),
+    detail = c(
+      paste0("expected columns=", ncol(expected), "; observed columns=", ncol(observed)),
+      paste0("expected rows=", nrow(expected), "; observed rows=", nrow(observed))
+    )
+  ) |>
+    dplyr::filter(!.data$passed)
+}
+
+assert_zoopla_reconciliation_schema <- function(old, candidate_long, candidate_study) {
+  required_old <- c(
+    "rental_id", "postcode", "address_line_01", "address_line_02",
+    "address_line_03", "listing_price", "latest_to_rent", "rented", "rented_est"
+  )
+  missing_old <- setdiff(required_old, names(old))
+  if (length(missing_old) > 0L) {
+    stop(
+      "Historical Zoopla data is missing required column(s): ",
+      paste(missing_old, collapse = ", "),
+      call. = FALSE
+    )
+  }
+  for (candidate in list(candidate_long, candidate_study)) {
+    if (!("rental_id" %in% names(candidate)) ||
+        anyNA(candidate$rental_id) || anyDuplicated(candidate$rental_id)) {
+      stop("Each Zoopla candidate must have unique, non-missing rental_id values.", call. = FALSE)
+    }
+  }
+  invisible(TRUE)
+}
+
+empty_zoopla_delta_table <- function() {
+  tibble::tibble(
+    rental_id = character(),
+    old_rental_id = character(),
+    column = character(),
+    old_value = character(),
+    new_value = character()
+  )
+}
+
+collect_zoopla_stable_value_deltas <- function(old_expected, candidate_study) {
+  stable_columns <- setdiff(
+    intersect(names(old_expected), names(candidate_study)),
+    c(ZOOPLA_STABLE_EXCLUDED_COLUMNS, ".stable_rental_id", ".old_rental_id")
+  )
+  if (length(stable_columns) == 0L) return(empty_zoopla_delta_table())
+
+  old_projection <- old_expected |>
+    dplyr::select(
+      ".stable_rental_id",
+      ".old_rental_id",
+      dplyr::all_of(stable_columns)
+    )
+  new_projection <- candidate_study |>
+    dplyr::rename(.stable_rental_id = "rental_id") |>
+    dplyr::select(".stable_rental_id", dplyr::all_of(stable_columns))
+  compared <- dplyr::inner_join(
+    old_projection,
+    new_projection,
+    by = ".stable_rental_id",
+    suffix = c("_old", "_new")
+  )
+
+  dplyr::bind_rows(lapply(stable_columns, function(column) {
+    old_value <- compared[[paste0(column, "_old")]]
+    new_value <- compared[[paste0(column, "_new")]]
+    changed <- !values_match(old_value, new_value)
+    changed[is.na(changed)] <- TRUE
+    tibble::tibble(
+      rental_id = compared$.stable_rental_id[changed],
+      old_rental_id = compared$.old_rental_id[changed],
+      column = column,
+      old_value = as.character(old_value[changed]),
+      new_value = as.character(new_value[changed])
+    )
+  }))
+}
+
+#' Enforce the rental R6a contract and quantify its two permitted sample shifts
+reconcile_zoopla_allowed_deltas <- function(
+    old,
+    candidate_long,
+    candidate_study,
+    study_years = 2021:2023,
+    long_run_years = 2014:2023,
+    base_year = 2021L) {
+  old <- tibble::as_tibble(old)
+  candidate_long <- tibble::as_tibble(candidate_long)
+  candidate_study <- tibble::as_tibble(candidate_study)
+  assert_zoopla_reconciliation_schema(old, candidate_long, candidate_study)
+
+  exact_columns <- setdiff(names(old), "rental_id")
+  exact_frame <- data.table::as.data.table(old[exact_columns])
+  duplicate_rows <- duplicated(exact_frame, by = exact_columns)
+  duplicate_members <- duplicate_rows |
+    duplicated(exact_frame, by = exact_columns, fromLast = TRUE)
+  duplicate_group_count <- if (any(duplicate_members)) {
+    data.table::uniqueN(exact_frame[duplicate_members], by = exact_columns)
+  } else {
+    0L
+  }
+  old_unique <- old[!duplicate_rows, , drop = FALSE] |>
+    dplyr::mutate(
+      .old_rental_id = as.character(.data$rental_id),
+      .stable_rental_id = hash_rental_identity(dplyr::pick(dplyr::everything()))
+    )
+
+  identity_conflicts <- old_unique |>
+    dplyr::count(.data$.stable_rental_id, name = "rows") |>
+    dplyr::filter(.data$rows > 1L) |>
+    dplyr::rename(rental_id = ".stable_rental_id")
+
+  old_unique <- old_unique |>
+    dplyr::mutate(
+      old_or_in_study = lubridate::year(.data$latest_to_rent) %in% study_years |
+        lubridate::year(.data$rented) %in% study_years,
+      rented_est_in_study = lubridate::year(.data$rented_est) %in% study_years
+    )
+  selection_removed <- old_unique |>
+    dplyr::filter(.data$old_or_in_study, !.data$rented_est_in_study) |>
+    dplyr::transmute(
+      rental_id = .data$.stable_rental_id,
+      old_rental_id = .data$.old_rental_id,
+      latest_to_rent = .data$latest_to_rent,
+      rented = .data$rented,
+      rented_est = .data$rented_est,
+      old_or_in_study = .data$old_or_in_study,
+      rented_est_in_study = .data$rented_est_in_study
+    )
+  expected_old <- old_unique |>
+    dplyr::filter(.data$rented_est_in_study)
+  expected_ids <- expected_old$.stable_rental_id
+  observed_ids <- candidate_study$rental_id
+
+  unexpected_membership_deltas <- dplyr::bind_rows(
+    tibble::tibble(
+      rental_id = setdiff(expected_ids, observed_ids),
+      issue = "rented_est_eligible_historical_row_missing_from_study_candidate"
+    ),
+    tibble::tibble(
+      rental_id = setdiff(observed_ids, expected_ids),
+      issue = "unexpected_study_candidate_row"
+    )
+  ) |>
+    dplyr::distinct()
+
+  value_deltas <- collect_zoopla_stable_value_deltas(expected_old, candidate_study)
+  period_issues <- zoopla_candidate_period_issues(candidate_long, base_year)
+  pair_issues <- zoopla_candidate_pair_issues(candidate_long, candidate_study, study_years)
+  long_window_issues <- candidate_long |>
+    dplyr::filter(
+      is.na(.data$rented_est) |
+        !lubridate::year(.data$rented_est) %in% long_run_years
+    ) |>
+    dplyr::select("rental_id", "rented_est")
+
+  dedupe_summary <- tibble::tibble(
+    old_rows = nrow(old),
+    deduplicated_rows = nrow(old_unique),
+    removed_rows = as.integer(sum(duplicate_rows)),
+    duplicate_groups = as.integer(duplicate_group_count)
+  )
+  summary <- tibble::tibble(
+    metric = c(
+      "old_rows", "old_rows_after_exact_dedupe", "dedupe_removed_rows",
+      "dedupe_groups", "or_to_rented_est_rows_removed", "candidate_long_rows",
+      "candidate_study_rows", "identity_conflicts", "unexpected_value_deltas",
+      "unexpected_membership_deltas", "candidate_period_issues",
+      "candidate_pair_issues", "long_window_issues"
+    ),
+    value = c(
+      nrow(old), nrow(old_unique), sum(duplicate_rows), duplicate_group_count,
+      nrow(selection_removed), nrow(candidate_long), nrow(candidate_study),
+      nrow(identity_conflicts), nrow(value_deltas),
+      nrow(unexpected_membership_deltas), nrow(period_issues),
+      nrow(pair_issues), nrow(long_window_issues)
+    )
+  )
+
+  list(
+    summary = summary,
+    dedupe_summary = dedupe_summary,
+    duplicate_records = old[duplicate_members, , drop = FALSE],
+    selection_removed = selection_removed,
+    identity_conflicts = identity_conflicts,
+    unexpected_value_deltas = value_deltas,
+    unexpected_membership_deltas = unexpected_membership_deltas,
+    candidate_period_issues = period_issues,
+    candidate_pair_issues = pair_issues,
+    long_window_issues = long_window_issues
+  )
+}
+
 #' Report immutable file facts for archived/current vintages and candidates
 build_file_vintage_report <- function(paths, vintage) {
   if (length(paths) == 0L || any(!file.exists(paths))) {
@@ -327,7 +559,10 @@ read_cleaning_candidate <- function(path) {
   list(data = tibble::as_tibble(table), metadata = table$metadata)
 }
 
-validate_shared_run_stamp <- function(long_metadata, study_metadata) {
+validate_shared_run_stamp <- function(
+    long_metadata,
+    study_metadata,
+    expected_market = "sales") {
   required <- c(
     "cleaning_manifest_version", "cleaning_run_stamp", "cleaning_market",
     "cleaning_artifact_role", "cleaning_year_min", "cleaning_year_max",
@@ -352,9 +587,9 @@ validate_shared_run_stamp <- function(long_metadata, study_metadata) {
     issues <- c(issues, "candidate manifest versions differ")
   }
   if (length(issues) == 0L &&
-      (!identical(long_metadata$cleaning_market, "sales") ||
-       !identical(study_metadata$cleaning_market, "sales"))) {
-    issues <- c(issues, "candidate market metadata is not sales")
+      (!identical(long_metadata$cleaning_market, expected_market) ||
+       !identical(study_metadata$cleaning_market, expected_market))) {
+    issues <- c(issues, paste0("candidate market metadata is not ", expected_market))
   }
   if (length(issues) == 0L && long_metadata$cleaning_artifact_role != "long_run") {
     issues <- c(issues, "long-run candidate role is not long_run")
@@ -502,6 +737,128 @@ run_lr_reconciliation <- function(config = default_reconciliation_config()) {
   ))
 }
 
+write_zoopla_reconciliation_tables <- function(result, output_dir) {
+  dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+  table_names <- c(
+    "summary", "dedupe_summary", "duplicate_records", "selection_removed",
+    "identity_conflicts", "unexpected_value_deltas",
+    "unexpected_membership_deltas", "candidate_period_issues",
+    "candidate_pair_issues", "long_window_issues"
+  )
+  for (name in table_names) {
+    utils::write.csv(
+      result[[name]],
+      file.path(output_dir, paste0("zoopla_", name, ".csv")),
+      row.names = FALSE,
+      na = ""
+    )
+  }
+  invisible(output_dir)
+}
+
+default_zoopla_reconciliation_config <- function() {
+  list(
+    old_study_path = here::here(
+      "data", "processed", "zoopla", "zoopla_rentals.parquet"
+    ),
+    candidate_long_path = here::here(
+      "data", "processed", "zoopla", "zoopla_rentals_long_run_candidate.parquet"
+    ),
+    candidate_study_path = here::here(
+      "data", "processed", "zoopla", "zoopla_rentals_candidate.parquet"
+    ),
+    raw_paths = c(
+      here::here("data", "raw", "zoopla", "rentals_safeguarded_2014-2022.csv"),
+      here::here("data", "raw", "zoopla", "rentals_safeguarded_2023.csv")
+    ),
+    output_dir = Sys.getenv(
+      "CLEANING_REBUILD_EVIDENCE_DIR",
+      unset = here::here("output", "cleaning_rebuild_reconciliation_2026-08-14")
+    ),
+    years = 2014:2023,
+    study_years = 2021:2023
+  )
+}
+
+run_zoopla_reconciliation <- function(
+    config = default_zoopla_reconciliation_config()) {
+  required_paths <- c(
+    config$old_study_path,
+    config$candidate_long_path,
+    config$candidate_study_path,
+    config$raw_paths
+  )
+  if (any(!file.exists(required_paths))) {
+    stop(
+      "Required Zoopla reconciliation artifact(s) missing: ",
+      paste(required_paths[!file.exists(required_paths)], collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  old <- arrow::read_parquet(config$old_study_path)
+  long_candidate <- read_cleaning_candidate(config$candidate_long_path)
+  study_candidate <- read_cleaning_candidate(config$candidate_study_path)
+  metadata_check <- validate_shared_run_stamp(
+    long_candidate$metadata,
+    study_candidate$metadata,
+    expected_market = "rentals"
+  )
+  result <- reconcile_zoopla_allowed_deltas(
+    old,
+    long_candidate$data,
+    study_candidate$data,
+    config$study_years,
+    config$years
+  )
+
+  dir.create(config$output_dir, recursive = TRUE, showWarnings = FALSE)
+  write_zoopla_reconciliation_tables(result, config$output_dir)
+  checksums <- build_file_vintage_report(
+    required_paths,
+    "zoopla_reconciliation_artifact"
+  )
+  utils::write.csv(
+    checksums,
+    file.path(config$output_dir, "zoopla_file_checksums.csv"),
+    row.names = FALSE,
+    na = ""
+  )
+  utils::write.csv(
+    metadata_check,
+    file.path(config$output_dir, "zoopla_candidate_metadata_check.csv"),
+    row.names = FALSE,
+    na = ""
+  )
+
+  blocking_count <- nrow(result$identity_conflicts) +
+    nrow(result$unexpected_value_deltas) +
+    nrow(result$unexpected_membership_deltas) +
+    nrow(result$candidate_period_issues) +
+    nrow(result$candidate_pair_issues) +
+    nrow(result$long_window_issues) +
+    sum(!metadata_check$passed)
+  if (blocking_count > 0L) {
+    stop(
+      "Zoopla cleaning reconciliation found ", blocking_count,
+      " contract violation(s). Review evidence in ", config$output_dir, ".",
+      call. = FALSE
+    )
+  }
+
+  invisible(list(
+    result = result,
+    metadata_check = metadata_check,
+    checksums = checksums,
+    output_dir = config$output_dir
+  ))
+}
+
 if (sys.nframe() == 0) {
-  run_lr_reconciliation()
+  args <- commandArgs(trailingOnly = TRUE)
+  if (length(args) > 0L && identical(args[[1]], "rentals")) {
+    run_zoopla_reconciliation()
+  } else {
+    run_lr_reconciliation()
+  }
 }

--- a/scripts/R/testing/reconcile_cleaning_rebuild.R
+++ b/scripts/R/testing/reconcile_cleaning_rebuild.R
@@ -1,0 +1,507 @@
+# ==============================================================================
+# Cleaning Rebuild Reconciliation
+# ==============================================================================
+#
+# Purpose: Produce non-mutating gate evidence for cleaning rebuild candidates.
+#          This U2 slice covers Land Registry old-versus-new allowed deltas,
+#          duplicate historical transaction IDs, paired-candidate metadata,
+#          and raw/input file checksums. U3 extends the same script for rentals.
+#
+# This script never promotes, replaces, archives, or deletes canonical data.
+#
+# ==============================================================================
+
+if (!requireNamespace("here", quietly = TRUE)) {
+  stop("Package `here` is required to run this script.", call. = FALSE)
+}
+
+source(here::here("scripts", "R", "utils", "hash_utils.R"), local = TRUE)
+
+LR_STABLE_EXCLUDED_COLUMNS <- c(
+  "house_id",
+  "transaction_id",
+  "date_of_transfer",
+  "qtr_id",
+  "month_id"
+)
+
+empty_delta_table <- function() {
+  tibble::tibble(
+    house_id = character(),
+    transaction_id = character(),
+    column = character(),
+    old_value = character(),
+    new_value = character()
+  )
+}
+
+values_match <- function(old, new) {
+  both_missing <- is.na(old) & is.na(new)
+  both_present <- !is.na(old) & !is.na(new)
+  both_missing | (both_present & as.character(old) == as.character(new))
+}
+
+assert_lr_reconciliation_schema <- function(old, candidate_long, candidate_study) {
+  if (!("transaction_id" %in% names(old))) {
+    stop("Historical LR data must retain transaction_id for reconciliation.", call. = FALSE)
+  }
+  if (!("house_id" %in% names(candidate_long)) ||
+      !("house_id" %in% names(candidate_study))) {
+    stop("Both LR candidates must contain house_id.", call. = FALSE)
+  }
+  if ("transaction_id" %in% names(candidate_long) ||
+      "transaction_id" %in% names(candidate_study)) {
+    stop("LR candidate schemas must not expose transaction_id.", call. = FALSE)
+  }
+  if (anyNA(candidate_long$house_id) || anyDuplicated(candidate_long$house_id)) {
+    stop("The LR long-run candidate must have unique, non-missing house_id values.", call. = FALSE)
+  }
+  if (anyNA(candidate_study$house_id) || anyDuplicated(candidate_study$house_id)) {
+    stop("The LR study candidate must have unique, non-missing house_id values.", call. = FALSE)
+  }
+  invisible(TRUE)
+}
+
+candidate_period_issues <- function(candidate_long, base_year = 2021L) {
+  expected_qtr <- (lubridate::year(candidate_long$date_of_transfer) - base_year) * 4L +
+    lubridate::quarter(candidate_long$date_of_transfer)
+  expected_month <- (lubridate::year(candidate_long$date_of_transfer) - base_year) * 12L +
+    lubridate::month(candidate_long$date_of_transfer)
+
+  bad <- is.na(candidate_long$date_of_transfer) |
+    is.na(candidate_long$qtr_id) |
+    is.na(candidate_long$month_id) |
+    candidate_long$qtr_id != expected_qtr |
+    candidate_long$month_id != expected_month
+
+  tibble::tibble(
+    house_id = candidate_long$house_id[bad],
+    date_of_transfer = candidate_long$date_of_transfer[bad],
+    qtr_id = candidate_long$qtr_id[bad],
+    expected_qtr_id = expected_qtr[bad],
+    month_id = candidate_long$month_id[bad],
+    expected_month_id = expected_month[bad]
+  )
+}
+
+candidate_pair_issues <- function(candidate_long, candidate_study, study_years) {
+  expected <- candidate_long[
+    lubridate::year(candidate_long$date_of_transfer) %in% study_years,
+    ,
+    drop = FALSE
+  ]
+  expected <- expected[order(expected$house_id), , drop = FALSE]
+  observed <- candidate_study[order(candidate_study$house_id), , drop = FALSE]
+
+  same_schema <- identical(names(expected), names(observed))
+  same_rows <- same_schema && isTRUE(all.equal(
+    as.data.frame(expected),
+    as.data.frame(observed),
+    check.attributes = FALSE
+  ))
+
+  tibble::tibble(
+    check = c("study_schema_equals_filtered_long_run", "study_rows_equal_filtered_long_run"),
+    passed = c(same_schema, same_rows),
+    detail = c(
+      paste0("expected columns=", ncol(expected), "; observed columns=", ncol(observed)),
+      paste0("expected rows=", nrow(expected), "; observed rows=", nrow(observed))
+    )
+  ) |>
+    dplyr::filter(!.data$passed)
+}
+
+collect_stable_value_deltas <- function(old_keyed, candidate_long) {
+  stable_columns <- setdiff(
+    intersect(names(old_keyed), names(candidate_long)),
+    c(LR_STABLE_EXCLUDED_COLUMNS, ".old_row", ".stable_house_id")
+  )
+  if (length(stable_columns) == 0L) return(empty_delta_table())
+
+  old_projection <- old_keyed |>
+    dplyr::select(
+      ".old_row",
+      ".stable_house_id",
+      "transaction_id",
+      dplyr::all_of(stable_columns)
+    )
+  new_projection <- candidate_long |>
+    dplyr::rename(.stable_house_id = "house_id") |>
+    dplyr::select(".stable_house_id", dplyr::all_of(stable_columns))
+  compared <- dplyr::left_join(
+    old_projection,
+    new_projection,
+    by = ".stable_house_id",
+    suffix = c("_old", "_new")
+  )
+
+  deltas <- lapply(stable_columns, function(column) {
+    old_value <- compared[[paste0(column, "_old")]]
+    new_value <- compared[[paste0(column, "_new")]]
+    changed <- !values_match(old_value, new_value)
+    changed[is.na(changed)] <- TRUE
+
+    tibble::tibble(
+      house_id = compared$.stable_house_id[changed],
+      transaction_id = compared$transaction_id[changed],
+      column = column,
+      old_value = as.character(old_value[changed]),
+      new_value = as.character(new_value[changed])
+    )
+  })
+
+  dplyr::bind_rows(deltas)
+}
+
+#' Compare the historical LR study file with rebuilt long-run/study candidates
+#'
+#' Allowed changes are the positional-to-hash ID flip, transaction_id removal,
+#' refreshed transfer dates and their period indices, and study membership
+#' implied by those refreshed dates. Other common-column changes are reported.
+reconcile_lr_allowed_deltas <- function(
+    old,
+    candidate_long,
+    candidate_study,
+    study_years = 2021:2024,
+    base_year = 2021L) {
+  old <- tibble::as_tibble(old)
+  candidate_long <- tibble::as_tibble(candidate_long)
+  candidate_study <- tibble::as_tibble(candidate_study)
+  assert_lr_reconciliation_schema(old, candidate_long, candidate_study)
+
+  old_keyed <- old |>
+    dplyr::mutate(
+      .old_row = dplyr::row_number(),
+      .stable_house_id = hash_transaction_id(.data$transaction_id)
+    )
+
+  old_duplicate_ids <- old_keyed |>
+    dplyr::count(.stable_house_id, name = "old_row_count") |>
+    dplyr::filter(.data$old_row_count > 1L) |>
+    dplyr::rename(house_id = ".stable_house_id")
+
+  new_projection <- candidate_long |>
+    dplyr::transmute(
+      .stable_house_id = .data$house_id,
+      new_date_of_transfer = .data$date_of_transfer,
+      new_qtr_id = .data$qtr_id,
+      new_month_id = .data$month_id,
+      in_candidate_long = TRUE
+    )
+  study_ids <- candidate_study$house_id
+
+  transitions <- old_keyed |>
+    dplyr::transmute(
+      .data$.old_row,
+      transaction_id = as.character(.data$transaction_id),
+      house_id = .data$.stable_house_id,
+      old_date_of_transfer = .data$date_of_transfer,
+      old_qtr_id = .data$qtr_id,
+      old_month_id = .data$month_id,
+      old_in_study_window = lubridate::year(.data$date_of_transfer) %in% study_years
+    ) |>
+    dplyr::left_join(
+      new_projection,
+      by = c("house_id" = ".stable_house_id")
+    ) |>
+    dplyr::mutate(
+      in_candidate_long = tidyr::replace_na(.data$in_candidate_long, FALSE),
+      new_in_study_window = lubridate::year(.data$new_date_of_transfer) %in% study_years,
+      in_candidate_study = .data$house_id %in% study_ids,
+      date_changed = .data$in_candidate_long &
+        !values_match(.data$old_date_of_transfer, .data$new_date_of_transfer),
+      qtr_changed = .data$in_candidate_long &
+        !values_match(.data$old_qtr_id, .data$new_qtr_id),
+      month_changed = .data$in_candidate_long &
+        !values_match(.data$old_month_id, .data$new_month_id),
+      membership_changed = .data$old_in_study_window != .data$in_candidate_study
+    )
+
+  unexpected_membership_deltas <- dplyr::bind_rows(
+    transitions |>
+      dplyr::filter(!.data$in_candidate_long) |>
+      dplyr::transmute(
+        house_id = .data$house_id,
+        issue = "historical_id_missing_from_long_run_candidate"
+      ),
+    transitions |>
+      dplyr::filter(
+        .data$in_candidate_long,
+        .data$new_in_study_window != .data$in_candidate_study
+      ) |>
+      dplyr::transmute(
+        house_id = .data$house_id,
+        issue = "study_membership_not_implied_by_candidate_date"
+      ),
+    tibble::tibble(
+      house_id = setdiff(candidate_study$house_id, candidate_long$house_id),
+      issue = "study_id_missing_from_long_run_candidate"
+    )
+  ) |>
+    dplyr::distinct()
+
+  duplicate_records <- old_keyed |>
+    dplyr::filter(.data$.stable_house_id %in% old_duplicate_ids$house_id) |>
+    dplyr::transmute(
+      house_id = .data$.stable_house_id,
+      transaction_id = as.character(.data$transaction_id),
+      old_date_of_transfer = .data$date_of_transfer,
+      old_qtr_id = .data$qtr_id,
+      old_month_id = .data$month_id
+    ) |>
+    dplyr::left_join(
+      dplyr::select(
+        candidate_long,
+        "house_id",
+        new_date_of_transfer = "date_of_transfer",
+        new_qtr_id = "qtr_id",
+        new_month_id = "month_id"
+      ),
+      by = "house_id"
+    ) |>
+    dplyr::mutate(retained_in_study_candidate = .data$house_id %in% study_ids)
+
+  period_issues <- candidate_period_issues(candidate_long, base_year)
+  pair_issues <- candidate_pair_issues(candidate_long, candidate_study, study_years)
+  value_deltas <- collect_stable_value_deltas(old_keyed, candidate_long)
+
+  new_subset_ids <- setdiff(candidate_study$house_id, unique(old_keyed$.stable_house_id))
+  removed_subset_ids <- setdiff(unique(old_keyed$.stable_house_id), candidate_study$house_id)
+
+  summary <- tibble::tibble(
+    metric = c(
+      "old_rows", "old_distinct_transaction_ids", "old_duplicate_transaction_ids",
+      "candidate_long_rows", "candidate_study_rows", "date_changes",
+      "qtr_changes", "month_changes", "study_ids_added", "study_ids_removed",
+      "unexpected_value_deltas", "unexpected_membership_deltas",
+      "candidate_period_issues", "candidate_pair_issues"
+    ),
+    value = c(
+      nrow(old), dplyr::n_distinct(old_keyed$.stable_house_id), nrow(old_duplicate_ids),
+      nrow(candidate_long), nrow(candidate_study), sum(transitions$date_changed, na.rm = TRUE),
+      sum(transitions$qtr_changed, na.rm = TRUE),
+      sum(transitions$month_changed, na.rm = TRUE),
+      length(new_subset_ids), length(removed_subset_ids),
+      nrow(value_deltas), nrow(unexpected_membership_deltas),
+      nrow(period_issues), nrow(pair_issues)
+    )
+  )
+
+  list(
+    summary = summary,
+    transitions = transitions,
+    old_duplicate_ids = old_duplicate_ids,
+    old_duplicate_records = duplicate_records,
+    study_ids_added = tibble::tibble(house_id = new_subset_ids),
+    study_ids_removed = tibble::tibble(house_id = removed_subset_ids),
+    unexpected_value_deltas = value_deltas,
+    unexpected_membership_deltas = unexpected_membership_deltas,
+    candidate_period_issues = period_issues,
+    candidate_pair_issues = pair_issues
+  )
+}
+
+#' Report immutable file facts for archived/current vintages and candidates
+build_file_vintage_report <- function(paths, vintage) {
+  if (length(paths) == 0L || any(!file.exists(paths))) {
+    missing <- paths[!file.exists(paths)]
+    stop(
+      "Cannot checksum missing file(s): ", paste(missing, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  info <- file.info(paths)
+  tibble::tibble(
+    vintage = as.character(vintage),
+    path = normalizePath(paths, mustWork = TRUE),
+    basename = basename(paths),
+    size_bytes = as.numeric(info$size),
+    mtime = format(info$mtime, "%Y-%m-%d %H:%M:%S %Z", tz = "UTC"),
+    sha256 = unname(tools::sha256sum(paths))
+  )
+}
+
+read_cleaning_candidate <- function(path) {
+  table <- arrow::read_parquet(path, as_data_frame = FALSE)
+  list(data = tibble::as_tibble(table), metadata = table$metadata)
+}
+
+validate_shared_run_stamp <- function(long_metadata, study_metadata) {
+  required <- c(
+    "cleaning_manifest_version", "cleaning_run_stamp", "cleaning_market",
+    "cleaning_artifact_role", "cleaning_year_min", "cleaning_year_max",
+    "cleaning_source_row_count", "cleaning_parent_role"
+  )
+  missing_long <- setdiff(required, names(long_metadata))
+  missing_study <- setdiff(required, names(study_metadata))
+  issues <- character()
+  if (length(missing_long)) {
+    issues <- c(issues, paste("long-run missing", paste(missing_long, collapse = ", ")))
+  }
+  if (length(missing_study)) {
+    issues <- c(issues, paste("study missing", paste(missing_study, collapse = ", ")))
+  }
+  if (length(issues) == 0L &&
+      !identical(long_metadata$cleaning_run_stamp, study_metadata$cleaning_run_stamp)) {
+    issues <- c(issues, "candidate run stamps differ")
+  }
+  if (length(issues) == 0L &&
+      !identical(long_metadata$cleaning_manifest_version,
+                 study_metadata$cleaning_manifest_version)) {
+    issues <- c(issues, "candidate manifest versions differ")
+  }
+  if (length(issues) == 0L &&
+      (!identical(long_metadata$cleaning_market, "sales") ||
+       !identical(study_metadata$cleaning_market, "sales"))) {
+    issues <- c(issues, "candidate market metadata is not sales")
+  }
+  if (length(issues) == 0L && long_metadata$cleaning_artifact_role != "long_run") {
+    issues <- c(issues, "long-run candidate role is not long_run")
+  }
+  if (length(issues) == 0L && study_metadata$cleaning_artifact_role != "study") {
+    issues <- c(issues, "study candidate role is not study")
+  }
+  if (length(issues) == 0L && study_metadata$cleaning_parent_role != "long_run") {
+    issues <- c(issues, "study candidate does not declare long_run parent")
+  }
+
+  tibble::tibble(
+    check = "shared_cleaning_run_stamp_contract",
+    passed = length(issues) == 0L,
+    detail = if (length(issues)) paste(issues, collapse = "; ") else
+      paste0("shared run stamp ", long_metadata$cleaning_run_stamp)
+  )
+}
+
+write_reconciliation_tables <- function(result, output_dir) {
+  dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+  table_names <- c(
+    "summary", "transitions", "old_duplicate_ids", "old_duplicate_records",
+    "study_ids_added", "study_ids_removed", "unexpected_value_deltas",
+    "unexpected_membership_deltas", "candidate_period_issues",
+    "candidate_pair_issues"
+  )
+  for (name in table_names) {
+    utils::write.csv(
+      result[[name]],
+      file.path(output_dir, paste0("lr_", name, ".csv")),
+      row.names = FALSE,
+      na = ""
+    )
+  }
+  invisible(output_dir)
+}
+
+default_reconciliation_config <- function() {
+  list(
+    old_study_path = here::here("data", "processed", "house_price.parquet"),
+    candidate_long_path = here::here(
+      "data", "processed", "house_price_long_run_candidate.parquet"
+    ),
+    candidate_study_path = here::here(
+      "data", "processed", "house_price_candidate.parquet"
+    ),
+    old_raw_dir = Sys.getenv("LR_REBUILD_OLD_RAW_DIR", unset = ""),
+    new_raw_dir = here::here("data", "raw", "lr_house_price"),
+    output_dir = Sys.getenv(
+      "CLEANING_REBUILD_EVIDENCE_DIR",
+      unset = here::here("output", "cleaning_rebuild_reconciliation_2026-08-14")
+    ),
+    years = 2014:2024,
+    study_years = 2021:2024
+  )
+}
+
+run_lr_reconciliation <- function(config = default_reconciliation_config()) {
+  if (!nzchar(config$old_raw_dir)) {
+    stop(
+      "Set LR_REBUILD_OLD_RAW_DIR to the dated archive of the pre-refresh raw vintage before gate reconciliation.",
+      call. = FALSE
+    )
+  }
+
+  required_data_paths <- c(
+    config$old_study_path,
+    config$candidate_long_path,
+    config$candidate_study_path
+  )
+  if (any(!file.exists(required_data_paths))) {
+    stop(
+      "Required LR reconciliation artifact(s) missing: ",
+      paste(required_data_paths[!file.exists(required_data_paths)], collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  expected_new_raw <- file.path(config$new_raw_dir, sprintf("pp-%d.csv", config$years))
+  if (any(!file.exists(expected_new_raw))) {
+    stop(
+      "The same-session LR refresh is incomplete; missing: ",
+      paste(basename(expected_new_raw[!file.exists(expected_new_raw)]), collapse = ", "),
+      call. = FALSE
+    )
+  }
+  old_raw <- list.files(config$old_raw_dir, pattern = "\\.csv$", full.names = TRUE)
+  if (length(old_raw) == 0L) {
+    stop("The archived LR raw vintage contains no CSV files.", call. = FALSE)
+  }
+
+  old <- arrow::read_parquet(config$old_study_path)
+  long_candidate <- read_cleaning_candidate(config$candidate_long_path)
+  study_candidate <- read_cleaning_candidate(config$candidate_study_path)
+  metadata_check <- validate_shared_run_stamp(
+    long_candidate$metadata,
+    study_candidate$metadata
+  )
+  result <- reconcile_lr_allowed_deltas(
+    old,
+    long_candidate$data,
+    study_candidate$data,
+    config$study_years
+  )
+
+  dir.create(config$output_dir, recursive = TRUE, showWarnings = FALSE)
+  write_reconciliation_tables(result, config$output_dir)
+  checksums <- dplyr::bind_rows(
+    build_file_vintage_report(old_raw, "archived_pre_refresh"),
+    build_file_vintage_report(expected_new_raw, "same_session_refresh"),
+    build_file_vintage_report(required_data_paths, "reconciliation_artifact")
+  )
+  utils::write.csv(
+    checksums,
+    file.path(config$output_dir, "lr_file_vintage_checksums.csv"),
+    row.names = FALSE,
+    na = ""
+  )
+  utils::write.csv(
+    metadata_check,
+    file.path(config$output_dir, "lr_candidate_metadata_check.csv"),
+    row.names = FALSE,
+    na = ""
+  )
+
+  blocking_count <- nrow(result$unexpected_value_deltas) +
+    nrow(result$unexpected_membership_deltas) +
+    nrow(result$candidate_period_issues) +
+    nrow(result$candidate_pair_issues) +
+    sum(!metadata_check$passed)
+  if (blocking_count > 0L) {
+    stop(
+      "LR cleaning reconciliation found ", blocking_count,
+      " contract violation(s). Review evidence in ", config$output_dir, ".",
+      call. = FALSE
+    )
+  }
+
+  invisible(list(
+    result = result,
+    metadata_check = metadata_check,
+    checksums = checksums,
+    output_dir = config$output_dir
+  ))
+}
+
+if (sys.nframe() == 0) {
+  run_lr_reconciliation()
+}

--- a/scripts/R/testing/rent_repeat_purchases.qmd
+++ b/scripts/R/testing/rent_repeat_purchases.qmd
@@ -129,44 +129,21 @@ repeat_summary_exact <- as_tibble(repeat_summary_exact)
 repeat_summary_exact
 ```
 
-## Export Rental Data (Repeated and Single)
+## Load the Canonical Mapping for the Study Window
 
 ```{r}
-# Prepare repeated rentals (rental_count > 1)
-repeated_rentals_output <- repeat_rentals_exact %>%
-  group_by(simple_key) %>%
-  mutate(
-    repeat_id = cur_group_id(),
-    group_size = n()
-  ) %>%
-  ungroup() %>%
-  arrange(desc(group_size)) %>%
-  select(rental_id, repeat_id)
-
-# Prepare single rentals (rental_count == 1)
-max_repeat_id <- max(repeated_rentals_output$repeat_id)
-single_rentals_output <- rent_dt[!is.na(simple_key) & rental_count == 1] %>%
-  as_tibble() %>%
-  mutate(repeat_id = max_repeat_id + row_number()) %>%
-  select(rental_id, repeat_id)
-
-# Combine both into single output
-all_rentals_output <- bind_rows(repeated_rentals_output, single_rentals_output)
-
-# Create output directory if it doesn't exist
-output_dir <- here::here("data", "processed", "repeated_transactions")
-if (!dir.exists(output_dir)) {
-  dir.create(output_dir, recursive = TRUE)
-}
-
-# Export to parquet
-output_path <- here::here(
-  "data",
-  "processed",
-  "repeated_transactions",
-  "repeated_rentals.parquet"
-)
-arrow::write_parquet(all_rentals_output, output_path)
+# The persisted repeat_count covers the 2014-2023 long-run input. Recompute it
+# after joining to this notebook's 2021-2023 study-window data.
+all_rentals_output <- import(
+  here::here(
+    "data", "processed", "repeated_transactions", "repeated_rentals.parquet"
+  ),
+  trust = TRUE
+) %>%
+  inner_join(rent_og %>% select(rental_id), by = "rental_id") %>%
+  group_by(repeat_id) %>%
+  mutate(repeat_count = n()) %>%
+  ungroup()
 ```
 
 ## Summary Table
@@ -236,12 +213,6 @@ repeat_rental_summary <- rentals_dt[
 ] %>%
   as_tibble()
 
-# Export to parquet
-output_path_sum <- here::here(
-  "data",
-  "processed",
-  "repeated_transactions",
-  "repeated_rentals_summary.parquet"
-)
-arrow::write_parquet(repeat_rental_summary, output_path_sum)
+# Diagnostic only: the retired summary artifact is no longer recreated.
+repeat_rental_summary
 ```

--- a/scripts/R/testing/sales_repeat_purchases.qmd
+++ b/scripts/R/testing/sales_repeat_purchases.qmd
@@ -75,7 +75,7 @@ sales_dt[grepl("^(NA\\|)*NA$", simple_key), simple_key := NA_character_]
 ## Exact Repeat Transactions
 
 ```{r}
-setorder(sales_dt, simple_key, date_of_transfer, transaction_id)
+setorder(sales_dt, simple_key, date_of_transfer, house_id)
 
 sales_dt[
   !is.na(simple_key),
@@ -105,40 +105,21 @@ repeat_sales_exact <- sales_dt[!is.na(simple_key) & sale_count > 1]
 repeat_sales_exact <- as_tibble(repeat_sales_exact)
 ```
 
-## Export Sales Data (Repeated and Single)
+## Load the Canonical Mapping for the Study Window
 
 ```{r}
-# Prepare repeated sales (sale_count > 1)
-repeated_sales_output <- repeat_sales_exact %>%
-  group_by(simple_key) %>%
-  mutate(repeat_id = cur_group_id()) %>%
-  ungroup() %>%
-  select(house_id, repeat_id)
-
-# Prepare single sales (sale_count == 1)
-max_repeat_id <- max(repeated_sales_output$repeat_id)
-single_sales_output <- sales_dt[!is.na(simple_key) & sale_count == 1] %>%
-  as_tibble() %>%
-  mutate(repeat_id = max_repeat_id + row_number()) %>%
-  select(house_id, repeat_id)
-
-# Combine both into single output
-all_sales_output <- bind_rows(repeated_sales_output, single_sales_output)
-
-# Create output directory if it doesn't exist
-output_dir <- here::here("data", "processed", "repeated_transactions")
-if (!dir.exists(output_dir)) {
-  dir.create(output_dir, recursive = TRUE)
-}
-
-# Export to parquet
-output_path <- here::here(
-  "data",
-  "processed",
-  "repeated_transactions",
-  "repeated_sales.parquet"
-)
-arrow::write_parquet(all_sales_output, output_path)
+# The persisted repeat_count covers the 2014-2024 long-run input. Recompute it
+# after joining to this notebook's 2021-2024 study-window data.
+all_sales_output <- import(
+  here::here(
+    "data", "processed", "repeated_transactions", "repeated_sales.parquet"
+  ),
+  trust = TRUE
+) %>%
+  inner_join(sales_og %>% select(house_id), by = "house_id") %>%
+  group_by(repeat_id) %>%
+  mutate(repeat_count = n()) %>%
+  ungroup()
 ```
 
 ## Summary Table
@@ -204,12 +185,6 @@ repeat_purchase_summary <- sales_dt[
 ] %>%
   as_tibble()
 
-# Export to parquet
-output_path_sum <- here::here(
-  "data",
-  "processed",
-  "repeated_transactions",
-  "repeated_sales_summary.parquet"
-)
-arrow::write_parquet(repeat_purchase_summary, output_path_sum)
+# Diagnostic only: the retired summary artifact is no longer recreated.
+repeat_purchase_summary
 ```

--- a/scripts/R/testing/sales_repeat_purchases2.qmd
+++ b/scripts/R/testing/sales_repeat_purchases2.qmd
@@ -77,7 +77,7 @@ rent_dt[grepl("^(NA\\|)*NA$", simple_key), simple_key := NA_character_]
 ### Exact Repeat Transactions
 
 ```{r}
-setorder(rent_dt, simple_key, date_of_transfer, transaction_id)
+setorder(rent_dt, simple_key, date_of_transfer, house_id)
 
 rent_dt[
   !is.na(simple_key),
@@ -144,7 +144,6 @@ rent_dt[,
 
 sales_linkage_dt <- rent_dt[, .(
   house_id,
-  transaction_id,
   date_of_transfer,
   price,
   postcode_clean,
@@ -293,7 +292,7 @@ rent_dt[,
 
 fuzzy_edges <- linked_data_set[
   mpost >= threshold_fuzzy,
-  .(from = transaction_id.x, to = transaction_id.y, mpost)
+  .(from = house_id.x, to = house_id.y, mpost)
 ]
 
 if (nrow(fuzzy_edges) > 0) {
@@ -304,14 +303,14 @@ if (nrow(fuzzy_edges) > 0) {
   comps <- igraph::components(g)
 
   component_map <- data.table(
-    transaction_id = names(comps$membership),
+    house_id = names(comps$membership),
     fuzzy_component = comps$membership
   )
 
   component_ids <- merge(
     component_map,
-    rent_dt[, .(transaction_id, property_id)],
-    by = "transaction_id",
+    rent_dt[, .(house_id, property_id)],
+    by = "house_id",
     all.x = TRUE
   )
 
@@ -343,11 +342,11 @@ if (nrow(fuzzy_edges) > 0) {
   rent_dt <- merge(
     rent_dt,
     component_map[, .(
-      transaction_id,
+      house_id,
       property_id_fuzzy = property_id,
       needs_review
     )],
-    by = "transaction_id",
+    by = "house_id",
     all.x = TRUE
   )
 
@@ -364,7 +363,7 @@ if (nrow(fuzzy_edges) > 0) {
   rent_dt[, c("property_id_fuzzy", "needs_review") := NULL]
 }
 
-setorder(rent_dt, property_id, date_of_transfer, transaction_id)
+setorder(rent_dt, property_id, date_of_transfer, house_id)
 
 panel_dt <- rent_dt[!is.na(property_id)]
 

--- a/scripts/R/testing/spill_count_variation_share_prior.qmd
+++ b/scripts/R/testing/spill_count_variation_share_prior.qmd
@@ -308,7 +308,6 @@ sales <- rio::import(
   add_month_id("date_of_transfer") |>
   dplyr::select(
     -dplyr::any_of(c(
-      "transaction_id",
       "date_of_transfer",
       "quality",
       "paon",

--- a/scripts/R/testing/test_cleaning_rebuild_contracts.R
+++ b/scripts/R/testing/test_cleaning_rebuild_contracts.R
@@ -1,0 +1,263 @@
+# ==============================================================================
+# Cleaning Rebuild Contract Tests
+# ==============================================================================
+
+# Runnable standalone via plain Rscript; exits non-zero on the first failure.
+
+assert_true <- function(condition, message) {
+  if (!isTRUE(condition)) stop(message, call. = FALSE)
+}
+
+assert_identical <- function(actual, expected, message) {
+  if (!identical(actual, expected)) {
+    stop(
+      paste0(
+        message,
+        "\nExpected: ", paste(capture.output(str(expected)), collapse = " "),
+        "\nActual: ", paste(capture.output(str(actual)), collapse = " ")
+      ),
+      call. = FALSE
+    )
+  }
+}
+
+assert_error_matching <- function(expr, pattern, message) {
+  err <- tryCatch({ force(expr); NULL }, error = identity)
+  assert_true(
+    inherits(err, "error") && grepl(pattern, conditionMessage(err), ignore.case = TRUE),
+    paste0(
+      message,
+      if (inherits(err, "error")) paste0("\nGot error: ", conditionMessage(err)) else "\nNo error was raised."
+    )
+  )
+}
+
+suppressPackageStartupMessages({
+  library(arrow)
+  library(dplyr)
+  library(here)
+  library(tibble)
+})
+
+cleaner_env <- new.env(parent = globalenv())
+sys.source(
+  here::here("scripts", "R", "02_data_cleaning", "clean_lr_house_price_data.R"),
+  envir = cleaner_env
+)
+
+reconcile_env <- new.env(parent = globalenv())
+sys.source(
+  here::here("scripts", "R", "testing", "reconcile_cleaning_rebuild.R"),
+  envir = reconcile_env
+)
+
+test_dir <- tempfile("cleaning-rebuild-contracts-")
+dir.create(test_dir, recursive = TRUE)
+on.exit(unlink(test_dir, recursive = TRUE), add = TRUE)
+
+years <- 2014:2024
+raw_dir <- file.path(test_dir, "raw")
+dir.create(raw_dir)
+
+# LR input discovery must reject the incomplete vintage before any file is read.
+invisible(file.create(file.path(raw_dir, sprintf("pp-%d.csv", years[-1]))))
+assert_error_matching(
+  cleaner_env$validate_expected_lr_files(raw_dir, years),
+  "pp-2014.csv",
+  "The exact eleven-file LR vintage must be present before loading starts."
+)
+invisible(file.create(file.path(raw_dir, "pp-2014.csv")))
+expected_paths <- cleaner_env$validate_expected_lr_files(raw_dir, years)
+assert_identical(
+  basename(expected_paths),
+  sprintf("pp-%d.csv", years),
+  "LR input discovery must return exact annual filenames in configured order."
+)
+assert_error_matching(
+  cleaner_env$validate_expected_lr_files(raw_dir, 2021:2024),
+  "exact 2014-2024",
+  "The LR cleaner must not silently shrink its locked long-run window."
+)
+
+raw_fixture <- tibble(
+  transaction_id = c("{A}", "{B}", "{C}"),
+  price = c(100000, 120000, 130000),
+  date_of_transfer = as.POSIXct(
+    c("2014-02-01 00:00:00", "2021-07-15 00:00:00", "2024-12-31 00:00:00"),
+    tz = "UTC"
+  ),
+  postcode = c("AB12CD", "AB12CD", "XY98ZT"),
+  property_type = c("T", "T", "F"),
+  old_new = "N",
+  duration = "F",
+  paon = c("1", "1", "2"),
+  saon = NA_character_,
+  street = c("HIGH STREET", "HIGH STREET", "LOW STREET"),
+  locality = "",
+  town_city = "TOWN",
+  district = "DISTRICT",
+  county = "COUNTY",
+  ppd_category = "A",
+  record_status = "A",
+  qtr_id = c(-27, 3, 16),
+  month_id = c(-83, 7, 48)
+)
+
+assert_error_matching(
+  cleaner_env$validate_lr_transactions(bind_rows(raw_fixture, raw_fixture[1, ]), years),
+  "duplicate",
+  "Duplicate transaction_id values must abort before outputs are built."
+)
+missing_id <- raw_fixture
+missing_id$transaction_id[1] <- NA_character_
+assert_error_matching(
+  cleaner_env$validate_lr_transactions(missing_id, years),
+  "missing",
+  "Missing transaction_id values must abort."
+)
+empty_id <- raw_fixture
+empty_id$transaction_id[1] <- ""
+assert_error_matching(
+  cleaner_env$validate_lr_transactions(empty_id, years),
+  "empty",
+  "Empty transaction_id values must abort."
+)
+outside_window <- raw_fixture
+outside_window$date_of_transfer[1] <- as.POSIXct("2013-12-31", tz = "UTC")
+assert_error_matching(
+  cleaner_env$validate_lr_transactions(outside_window, years),
+  "2014.*2024",
+  "Dates outside the configured long-run window must abort."
+)
+
+postcode_lookup <- tibble(
+  postcode = c("AB12CD", "XY98ZT"),
+  longitude = c(-1, -2),
+  latitude = c(51, 52)
+)
+assert_error_matching(
+  cleaner_env$enrich_lr_postcodes(raw_fixture, bind_rows(postcode_lookup, postcode_lookup[1, ])),
+  "duplicate",
+  "Postcode enrichment must reject a non-unique lookup."
+)
+
+enriched <- cleaner_env$enrich_lr_postcodes(raw_fixture, postcode_lookup)
+assert_identical(nrow(enriched), nrow(raw_fixture), "Postcode enrichment must preserve LR row count.")
+
+pair <- cleaner_env$build_lr_output_pair(
+  enriched,
+  long_run_years = years,
+  study_years = 2021:2024
+)
+assert_identical(nrow(pair$long_run), 3L, "The long-run output must retain every valid LR row.")
+assert_identical(nrow(pair$study), 2L, "The study output must be a 2021-2024 filter of the long-run output.")
+assert_true(!("transaction_id" %in% names(pair$long_run)), "transaction_id must be absent from the long-run schema.")
+assert_true(!("transaction_id" %in% names(pair$study)), "transaction_id must be absent from the study schema.")
+assert_true(all(grepl("^[0-9a-f]{16}$", pair$long_run$house_id)), "house_id must be lowercase xxhash64 hex.")
+assert_identical(
+  pair$long_run$house_id,
+  cleaner_env$hash_transaction_id(raw_fixture$transaction_id),
+  "house_id must be the deterministic hash of source transaction_id."
+)
+assert_identical(
+  pair$study$house_id,
+  pair$long_run$house_id[pair$long_run$house_id %in% pair$study$house_id],
+  "Study rows must carry the house_id assigned in the superset."
+)
+assert_identical(
+  pair$study,
+  filter(pair$long_run, lubridate::year(.data$date_of_transfer) %in% 2021:2024),
+  "The study output must equal a pure filter of the long-run output."
+)
+
+# Candidate publication must refuse canonical-looking paths and stamp both files
+# with one shared run identifier.
+assert_error_matching(
+  cleaner_env$write_cleaning_candidate(pair$study, file.path(test_dir, "house_price.parquet"), list()),
+  "candidate",
+  "The cleaner must refuse writes to canonical output paths."
+)
+
+long_path <- file.path(test_dir, "house_price_long_run_candidate.parquet")
+study_path <- file.path(test_dir, "house_price_candidate.parquet")
+run_stamp <- "2026-08-14T12:34:56Z"
+cleaner_env$write_lr_candidates(pair, long_path, study_path, run_stamp = run_stamp)
+drifted_pair <- pair
+drifted_pair$study$price[1] <- drifted_pair$study$price[1] + 1
+assert_error_matching(
+  cleaner_env$write_lr_candidates(
+    drifted_pair,
+    file.path(test_dir, "drifted_long_run_candidate.parquet"),
+    file.path(test_dir, "drifted_candidate.parquet"),
+    run_stamp = run_stamp
+  ),
+  "unchanged filter",
+  "Candidate publication must reject independently built or drifted study data."
+)
+
+long_table <- arrow::read_parquet(long_path, as_data_frame = FALSE)
+study_table <- arrow::read_parquet(study_path, as_data_frame = FALSE)
+required_metadata <- c(
+  "cleaning_manifest_version", "cleaning_run_stamp", "cleaning_market",
+  "cleaning_artifact_role", "cleaning_year_min", "cleaning_year_max",
+  "cleaning_source_row_count", "cleaning_parent_role"
+)
+assert_true(all(required_metadata %in% names(long_table$metadata)), "The LR superset must carry the cleaning metadata contract.")
+assert_true(all(required_metadata %in% names(study_table$metadata)), "The LR subset must carry the cleaning metadata contract.")
+assert_identical(long_table$metadata$cleaning_run_stamp, run_stamp, "The LR superset run stamp must round-trip.")
+assert_identical(study_table$metadata$cleaning_run_stamp, run_stamp, "Superset and subset must share one run stamp.")
+assert_identical(long_table$metadata$cleaning_artifact_role, "long_run", "The superset metadata must declare its role.")
+assert_identical(study_table$metadata$cleaning_parent_role, "long_run", "The subset metadata must declare derivation from the superset.")
+
+# LR reconciliation permits identity/date-period/membership transitions only.
+old <- raw_fixture[2:3, ] |>
+  mutate(house_id = seq_len(n()), .before = transaction_id)
+candidate_long <- pair$long_run
+candidate_study <- pair$study
+
+reconciliation <- reconcile_env$reconcile_lr_allowed_deltas(
+  old,
+  candidate_long,
+  candidate_study,
+  study_years = 2021:2024
+)
+assert_identical(nrow(reconciliation$unexpected_value_deltas), 0L, "Unchanged fixture rows must satisfy the LR allowed-delta contract.")
+assert_identical(nrow(reconciliation$unexpected_membership_deltas), 0L, "Valid date-based membership must satisfy the LR contract.")
+
+corrected_long <- candidate_long
+corrected_id <- cleaner_env$hash_transaction_id("{B}")
+corrected_long$date_of_transfer[corrected_long$house_id == corrected_id] <-
+  as.POSIXct("2020-12-31", tz = "UTC")
+corrected_long$qtr_id[corrected_long$house_id == corrected_id] <- 0L
+corrected_long$month_id[corrected_long$house_id == corrected_id] <- 0L
+corrected_study <- filter(
+  corrected_long,
+  lubridate::year(.data$date_of_transfer) %in% 2021:2024
+)
+corrected <- reconcile_env$reconcile_lr_allowed_deltas(
+  old,
+  corrected_long,
+  corrected_study,
+  2021:2024
+)
+corrected_transition <- filter(corrected$transitions, .data$house_id == corrected_id)
+assert_true(corrected_transition$date_changed[[1]], "A same-vintage date correction must be reported.")
+assert_true(corrected_transition$membership_changed[[1]], "A date-driven study-membership transition must be reported.")
+assert_identical(nrow(corrected$unexpected_value_deltas), 0L, "Date and implied period changes are allowed LR deltas.")
+assert_identical(nrow(corrected$unexpected_membership_deltas), 0L, "Date-implied study membership changes are allowed LR deltas.")
+
+changed_price <- candidate_long
+changed_price$price[changed_price$house_id == cleaner_env$hash_transaction_id("{B}")] <- 999999
+unexpected <- reconcile_env$reconcile_lr_allowed_deltas(old, changed_price, candidate_study, 2021:2024)
+assert_true(nrow(unexpected$unexpected_value_deltas) == 1L, "A non-allowed LR value change must be reported.")
+assert_true("price" %in% unexpected$unexpected_value_deltas$column, "The reconciliation must name the drifted column.")
+
+duplicate_old <- bind_rows(old, old[1, ] |> mutate(date_of_transfer = as.POSIXct("2020-12-31", tz = "UTC")))
+duplicates <- reconcile_env$reconcile_lr_allowed_deltas(duplicate_old, candidate_long, candidate_study, 2021:2024)
+assert_true(nrow(duplicates$old_duplicate_ids) == 1L, "Historical duplicate transaction ids must be called out for the gate.")
+
+vintage_report <- reconcile_env$build_file_vintage_report(c(long_path, study_path), "fixture")
+assert_true(all(c("vintage", "path", "basename", "size_bytes", "mtime", "sha256") %in% names(vintage_report)), "Vintage reports must include checksums and file facts.")
+assert_true(all(grepl("^[0-9a-f]{64}$", vintage_report$sha256)), "Vintage reports must carry SHA-256 checksums.")
+
+message("Cleaning rebuild contract tests passed (LR/U2 slice).")

--- a/scripts/R/testing/test_cleaning_rebuild_contracts.R
+++ b/scripts/R/testing/test_cleaning_rebuild_contracts.R
@@ -45,6 +45,12 @@ sys.source(
   envir = cleaner_env
 )
 
+zoopla_env <- new.env(parent = globalenv())
+sys.source(
+  here::here("scripts", "R", "02_data_cleaning", "clean_zoopla_data.R"),
+  envir = zoopla_env
+)
+
 reconcile_env <- new.env(parent = globalenv())
 sys.source(
   here::here("scripts", "R", "testing", "reconcile_cleaning_rebuild.R"),
@@ -261,3 +267,186 @@ assert_true(all(c("vintage", "path", "basename", "size_bytes", "mtime", "sha256"
 assert_true(all(grepl("^[0-9a-f]{64}$", vintage_report$sha256)), "Vintage reports must carry SHA-256 checksums.")
 
 message("Cleaning rebuild contract tests passed (LR/U2 slice).")
+
+# Zoopla/U3: rented_est is the sole window field, exact duplicates disappear
+# before identity assignment, and the study candidate is a pure superset filter.
+zoopla_raw <- tibble(
+  zp.Address1 = c("1 HIGH STREET", "1 HIGH STREET", "2 LOW STREET", "3 OLD ROAD", "4 NEW ROAD"),
+  zp.Address2 = c(NA, NA, "FLAT A", NA, NA),
+  zp.Address3 = NA_character_,
+  zp.Postcode = c("AB1 2CD", "AB1 2CD", "XY9 8ZT", "ZZ1 1ZZ", "XY9 8ZT"),
+  zp.PropertyType = c("Terraced", "Terraced", "Flat", "Detached", "Flat"),
+  zp.Bedrooms = c(2, 2, 1, 3, 2),
+  zp.Bathrooms = 1,
+  zp.Receptions = 1,
+  zp.Floors = 1,
+  zp.ListingCreated = as.Date(c("2020-12-01", "2020-12-01", "2020-11-01", "2014-01-01", "2023-01-01")),
+  zp.ListingPageViews = c(10, 10, 20, 30, 40),
+  zp.ListingPrice = c(1000, 1000, 1100, 900, 1200),
+  zp.LatestToRent = as.Date(c("2020-12-31", "2020-12-31", "2021-01-05", "2014-02-01", NA)),
+  zp.Rented = as.Date(c("2021-01-02", "2021-01-02", "2020-12-30", NA, "2023-03-01")),
+  epc.EnergyEfficiency = c(70, 70, 65, 60, 75),
+  epc.EnergyRating = c("C", "C", "D", "D", "C")
+)
+
+zoopla_cleaned <- zoopla_env$clean_zoopla_data(
+  zoopla_raw,
+  years = 2014:2023,
+  track_raw_origin = TRUE
+)
+assert_identical(
+  lubridate::year(zoopla_cleaned$rented_est),
+  c(2021, 2021, 2020, 2014, 2023),
+  "Zoopla long-run selection must be based exclusively on coalesce(rented, latest_to_rent)."
+)
+assert_identical(
+  zoopla_cleaned$rented_est,
+  dplyr::coalesce(zoopla_cleaned$rented, zoopla_cleaned$latest_to_rent),
+  "rented_est must retain the existing coalesce(rented, latest_to_rent) rule exactly."
+)
+
+deduped <- zoopla_env$deduplicate_zoopla_transactions(zoopla_cleaned, zoopla_raw)
+assert_identical(deduped$removed_count, 1L, "Zoopla exact-duplicate removal must report removed rows.")
+assert_identical(deduped$duplicate_group_count, 1L, "Zoopla exact-duplicate removal must report duplicate groups.")
+assert_identical(nrow(deduped$data), 4L, "Zoopla exact duplicates must be removed before ID assignment.")
+assert_true(!(".raw_origin_row" %in% names(deduped$data)), "Raw-origin helper columns must not leak into outputs.")
+assert_true(
+  nrow(deduped$origin_spot_check) == 2L &&
+    identical(deduped$origin_spot_check$.raw_origin_row, c(1L, 2L)),
+  "The duplicate report must retain a raw-origin spot check for one duplicate group."
+)
+
+zoopla_lookup <- tibble(
+  postcode = c("AB12CD", "XY98ZT", "ZZ11ZZ"),
+  longitude = c(-1, -2, -3),
+  latitude = c(51, 52, 53)
+)
+assert_error_matching(
+  zoopla_env$enrich_zoopla_postcodes(
+    deduped$data,
+    bind_rows(zoopla_lookup, zoopla_lookup[1, ])
+  ),
+  "duplicate",
+  "Zoopla postcode enrichment must reject a non-unique lookup."
+)
+zoopla_enriched <- zoopla_env$enrich_zoopla_postcodes(deduped$data, zoopla_lookup)
+assert_identical(nrow(zoopla_enriched), nrow(deduped$data), "Zoopla postcode enrichment must preserve row count.")
+
+zoopla_pair <- zoopla_env$build_zoopla_output_pair(
+  zoopla_enriched,
+  long_run_years = 2014:2023,
+  study_years = 2021:2023
+)
+assert_identical(nrow(zoopla_pair$long_run), 4L, "The Zoopla superset must retain every valid deduplicated row.")
+assert_identical(nrow(zoopla_pair$study), 2L, "The Zoopla study output must use rented_est, not the old OR filter.")
+assert_true(all(grepl("^[0-9a-f]{16}$", zoopla_pair$long_run$rental_id)), "rental_id must be lowercase xxhash64 hex.")
+assert_true(!anyDuplicated(zoopla_pair$long_run$rental_id), "The long-run rental_id must be unique.")
+assert_true(all(zoopla_pair$study$qtr_id > 0), "The 2021-2023 study candidate cannot contain negative qtr_id values.")
+assert_identical(
+  zoopla_pair$study,
+  filter(zoopla_pair$long_run, lubridate::year(.data$rented_est) %in% 2021:2023),
+  "The Zoopla study output must equal a pure filter of the long-run output."
+)
+assert_identical(
+  zoopla_pair$long_run$rental_id,
+  zoopla_env$hash_rental_identity(zoopla_pair$long_run),
+  "rental_id must hash the locked seven-field post-cleaning composite."
+)
+assert_true(
+  any(is.na(zoopla_pair$long_run$rented)) && any(is.na(zoopla_pair$long_run$latest_to_rent)),
+  "The rental identity fixture must exercise both missing date fields."
+)
+second_pair <- zoopla_env$build_zoopla_output_pair(zoopla_enriched, 2014:2023, 2021:2023)
+assert_identical(
+  second_pair$long_run$rental_id,
+  zoopla_pair$long_run$rental_id,
+  "Two Zoopla builds must produce byte-identical rental_id vectors."
+)
+
+composite_collision <- bind_rows(
+  zoopla_enriched,
+  zoopla_enriched[1, ] |> mutate(property_type = "F")
+)
+assert_error_matching(
+  zoopla_env$build_zoopla_output_pair(composite_collision, 2014:2023, 2021:2023),
+  "composite",
+  "A non-unique seven-field rental identity composite must abort."
+)
+
+original_hash_function <- zoopla_env$hash_rental_identity
+zoopla_env$hash_rental_identity <- function(data) rep("0000000000000000", nrow(data))
+assert_error_matching(
+  zoopla_env$build_zoopla_output_pair(zoopla_enriched, 2014:2023, 2021:2023),
+  "hash",
+  "A rental_id hash collision must abort independently of composite uniqueness."
+)
+zoopla_env$hash_rental_identity <- original_hash_function
+
+zoopla_long_path <- file.path(test_dir, "zoopla_rentals_long_run_candidate.parquet")
+zoopla_study_path <- file.path(test_dir, "zoopla_rentals_candidate.parquet")
+zoopla_run_stamp <- "2026-08-14T12:35:57Z"
+zoopla_env$write_zoopla_candidates(
+  zoopla_pair,
+  zoopla_long_path,
+  zoopla_study_path,
+  run_stamp = zoopla_run_stamp,
+  source_row_count = nrow(zoopla_raw),
+  removed_duplicate_count = deduped$removed_count
+)
+zoopla_long_table <- arrow::read_parquet(zoopla_long_path, as_data_frame = FALSE)
+zoopla_study_table <- arrow::read_parquet(zoopla_study_path, as_data_frame = FALSE)
+assert_identical(zoopla_long_table$metadata$cleaning_run_stamp, zoopla_run_stamp, "The Zoopla superset run stamp must round-trip.")
+assert_identical(zoopla_study_table$metadata$cleaning_run_stamp, zoopla_run_stamp, "Zoopla outputs must share one run stamp.")
+assert_identical(zoopla_long_table$metadata$cleaning_market, "rentals", "Zoopla metadata must declare the rentals market.")
+assert_identical(zoopla_study_table$metadata$cleaning_parent_role, "long_run", "The Zoopla study candidate must declare derivation from the superset.")
+assert_identical(zoopla_long_table$metadata$cleaning_removed_duplicate_rows, "1", "Zoopla metadata must record the dedupe count.")
+
+# Reconstruct the historical OR-selected study file from the same cleaned raw
+# fixture. It contains one exact duplicate and one row selected solely because
+# latest_to_rent is in-window while rented_est (rented) is not.
+old_zoopla <- zoopla_cleaned |>
+  select(-".raw_origin_row") |>
+  filter(
+    lubridate::year(.data$latest_to_rent) %in% 2021:2023 |
+      lubridate::year(.data$rented) %in% 2021:2023
+  ) |>
+  left_join(zoopla_lookup, by = "postcode") |>
+  mutate(rental_id = row_number(), .before = 1)
+
+zoopla_reconciliation <- reconcile_env$reconcile_zoopla_allowed_deltas(
+  old_zoopla,
+  zoopla_pair$long_run,
+  zoopla_pair$study,
+  study_years = 2021:2023
+)
+assert_identical(zoopla_reconciliation$dedupe_summary$removed_rows[[1]], 1L, "Rental reconciliation must quantify exact-duplicate removal.")
+assert_identical(nrow(zoopla_reconciliation$selection_removed), 1L, "Rental reconciliation must quantify the OR-to-rented_est selection shift.")
+assert_identical(nrow(zoopla_reconciliation$unexpected_value_deltas), 0L, "Allowed rental rebuild changes must preserve stable columns.")
+assert_identical(nrow(zoopla_reconciliation$unexpected_membership_deltas), 0L, "Only dedupe and rented_est selection may change rental membership.")
+
+drifted_zoopla <- zoopla_pair$study
+drifted_zoopla$listing_page_views[1] <- drifted_zoopla$listing_page_views[1] + 1
+zoopla_value_drift <- reconcile_env$reconcile_zoopla_allowed_deltas(
+  old_zoopla,
+  zoopla_pair$long_run,
+  drifted_zoopla,
+  2021:2023
+)
+assert_true(
+  "listing_page_views" %in% zoopla_value_drift$unexpected_value_deltas$column,
+  "Rental reconciliation must name non-allowed stable-column drift."
+)
+
+missing_zoopla <- zoopla_pair$study[-1, ]
+zoopla_member_drift <- reconcile_env$reconcile_zoopla_allowed_deltas(
+  old_zoopla,
+  zoopla_pair$long_run,
+  missing_zoopla,
+  2021:2023
+)
+assert_true(
+  nrow(zoopla_member_drift$unexpected_membership_deltas) > 0L,
+  "Rental reconciliation must reject membership changes beyond dedupe and rented_est selection."
+)
+
+message("Cleaning rebuild contract tests passed (Zoopla/U3 slice).")

--- a/scripts/R/testing/test_cross_section_study_period_contracts.R
+++ b/scripts/R/testing/test_cross_section_study_period_contracts.R
@@ -237,6 +237,14 @@ source_fixture <- data.table(
   easting = c(500000, 500100, NA, 500200),
   northing = c(200000, 200100, 200200, 200200)
 )
+assert_error_contains(
+  study_period_source_ledger(
+    copy(source_fixture)[, house_id := seq_len(.N)],
+    sales_contract
+  ),
+  "character transaction identifiers",
+  "Study-period source ledgers must reject stale positional integer IDs."
+)
 leading_zero_source <- copy(source_fixture[1:2])
 leading_zero_source[, house_id := c("01leadingzero", "02stablehash")]
 leading_zero_ledger <- study_period_source_ledger(

--- a/scripts/R/testing/test_cross_section_study_period_contracts.R
+++ b/scripts/R/testing/test_cross_section_study_period_contracts.R
@@ -99,7 +99,7 @@ rental_schema <- study_period_public_schema("rental")
 assert_identical(
   schema_signature(sales_schema),
   c(
-    house_id = "int32", price = "int32", ppd_category = "string",
+    house_id = "string", price = "int32", ppd_category = "string",
     n_days_in_window = "int32", spill_hrs = "double",
     n_spill_sites = "int32", spill_count = "double",
     mean_distance = "double", min_distance = "double",
@@ -113,7 +113,7 @@ assert_identical(
 assert_identical(
   schema_signature(rental_schema),
   c(
-    rental_id = "int32", listing_price = "double",
+    rental_id = "string", listing_price = "double",
     n_days_in_window = "int32", spill_hrs = "double",
     n_spill_sites = "int32", spill_count = "double",
     mean_distance = "double", min_distance = "double",
@@ -231,11 +231,22 @@ for (case in invalid_cases) {
 
 sales_contract <- study_period_market_contract("sale")
 source_fixture <- data.table(
-  house_id = 1:4,
+  house_id = as.character(1:4),
   price = c(100000L, 200000L, 300000L, 400000L),
   ppd_category = c("A", "B", "A", "B"),
   easting = c(500000, 500100, NA, 500200),
   northing = c(200000, 200100, 200200, 200200)
+)
+leading_zero_source <- copy(source_fixture[1:2])
+leading_zero_source[, house_id := c("01leadingzero", "02stablehash")]
+leading_zero_ledger <- study_period_source_ledger(
+  leading_zero_source,
+  sales_contract
+)
+assert_identical(
+  leading_zero_ledger$house_id,
+  c("01leadingzero", "02stablehash"),
+  "The source ledger must preserve character IDs including a leading zero."
 )
 ledger <- study_period_source_ledger(source_fixture, sales_contract)
 assert_identical(
@@ -252,14 +263,14 @@ site_totals <- data.table(
 )
 
 lookup_group_one <- data.table(
-  house_id = c(1L, 2L, 2L),
+  house_id = c("1", "2", "2"),
   site_id = c(NA_integer_, 10L, 20L),
   distance_m = c(NA, 300, 750),
   distance_km = c(NA, 0.3, 0.75),
   n_site_groups = c(0L, 2L, 2L)
 )
 lookup_group_two <- data.table(
-  house_id = c(4L, 4L, 4L),
+  house_id = c("4", "4", "4"),
   site_id = c(30L, 40L, 50L),
   distance_m = c(250, 500, 1000),
   distance_km = c(0.25, 0.5, 1),
@@ -277,30 +288,30 @@ reduced_one <- study_period_reduce_lookup_row_group(
 setkey(reduced_one, house_id, radius)
 
 assert_true(
-  reduced_one[.(1L, 250L),
+  reduced_one[.("1", 250L),
     n_spill_sites == 0L && spatially_eligible && !has_missing_site &&
       spill_count == 0 && spill_hrs == 0 && is.na(min_distance)],
   "An eligible sentinel must produce a known true zero at every radius."
 )
 assert_true(
-  reduced_one[.(2L, 250L),
+  reduced_one[.("2", 250L),
     n_spill_sites == 0L && spill_count == 0 && is.na(mean_distance)],
   "A site outside 250 m must not destroy the nested-radius zero."
 )
 assert_true(
-  reduced_one[.(2L, 500L),
+  reduced_one[.("2", 500L),
     n_spill_sites == 1L && spill_count == 3 && spill_hrs == 7 &&
       min_distance == 300 && !has_missing_site],
   "The 500 m row must include only the 300 m complete-evidence site."
 )
 assert_true(
-  reduced_one[.(2L, 1000L),
+  reduced_one[.("2", 1000L),
     n_spill_sites == 2L && min_distance == 300 && mean_distance == 525 &&
       has_missing_site && is.na(spill_count) && is.na(spill_hrs)],
   "Unknown evidence must preserve known geography while masking exposure."
 )
 assert_true(
-  reduced_one[.(2L, 500L),
+  reduced_one[.("2", 500L),
     spill_count_daily_avg == 3 / 1461 &&
       spill_count_weekly_avg == 3 / 1461 * 7],
   "Daily and weekly rates must derive from the validated inclusive day count."
@@ -316,9 +327,38 @@ reduced_two <- study_period_reduce_lookup_row_group(
 )
 setkey(reduced_two, house_id, radius)
 assert_identical(
-  reduced_two[.(4L, c(250L, 500L, 1000L)), n_spill_sites],
+  reduced_two[.("4", c(250L, 500L, 1000L)), n_spill_sites],
   c(1L, 2L, 3L),
   "Sites exactly on each boundary must enter that radius and every larger one."
+)
+
+lookup_group_all_outside <- data.table(
+  house_id = "4",
+  site_id = 30L,
+  distance_m = 1000.01,
+  distance_km = 1000.01 / 1000,
+  n_site_groups = 1L
+)
+reduced_all_outside <- study_period_reduce_lookup_row_group(
+  lookup_group_all_outside,
+  ledger,
+  site_totals,
+  sales_contract,
+  radii = c(250L, 500L, 1000L),
+  n_days_in_window = 1461L
+)
+assert_true(
+  nrow(reduced_all_outside) == 3L &&
+    all(reduced_all_outside$n_spill_sites == 0L) &&
+    all(reduced_all_outside$spill_count == 0) &&
+    all(reduced_all_outside$spill_hrs == 0) &&
+    all(is.na(reduced_all_outside$mean_distance)) &&
+    all(is.na(reduced_all_outside$min_distance)) &&
+    all(!reduced_all_outside$has_missing_site),
+  paste0(
+    "A row group whose valid matches all exceed the maximum radius must ",
+    "produce known true-zero exposure at every radius."
+  )
 )
 
 rental_contract <- study_period_market_contract("rental")
@@ -428,7 +468,7 @@ assert_error_contains(
 
 write_lookup_fixture <- function(path, groups, contract) {
   schema <- arrow::schema(
-    house_id = arrow::int32(),
+    house_id = arrow::utf8(),
     site_id = arrow::int32(),
     distance_m = arrow::float64(),
     distance_km = arrow::float64(),
@@ -438,6 +478,8 @@ write_lookup_fixture <- function(path, groups, contract) {
   properties <- arrow::ParquetWriterProperties$create(names(schema))
   writer <- arrow::ParquetFileWriter$create(schema, stream, properties = properties)
   for (group in groups) {
+    group <- copy(group)
+    group[[contract$id]] <- as.character(group[[contract$id]])
     batch <- arrow::RecordBatch$create(group, schema = schema)
     writer$WriteBatch(batch, chunk_size = batch$num_rows)
   }

--- a/scripts/R/testing/test_duckdb_panel_refresh_contracts.R
+++ b/scripts/R/testing/test_duckdb_panel_refresh_contracts.R
@@ -1,0 +1,230 @@
+# ==============================================================================
+# DuckDB Panel Input Refresh Contract Tests
+# ==============================================================================
+
+suppressPackageStartupMessages({
+  library(arrow)
+  library(DBI)
+  library(dbplyr)
+  library(dplyr)
+  library(duckdb)
+  library(here)
+  library(logger)
+  library(lubridate)
+})
+
+assert_true <- function(condition, message) {
+  if (!isTRUE(condition)) stop(message, call. = FALSE)
+}
+
+relation_type <- function(con, table_name) {
+  DBI::dbGetQuery(
+    con,
+    paste(
+      "SELECT table_type FROM information_schema.tables",
+      "WHERE table_schema = 'main' AND table_name = ?"
+    ),
+    params = list(table_name)
+  )$table_type
+}
+
+write_fixture_inputs <- function(processed_dir, market, ids) {
+  if (identical(market, "sales")) {
+    arrow::write_parquet(
+      data.frame(
+        house_id = ids,
+        price = c(100000L, 200000L),
+        date_of_transfer = as.POSIXct(
+          c("2021-01-01", "2022-01-01"), tz = "UTC"
+        ),
+        qtr_id = c(1, 5)
+      ),
+      file.path(processed_dir, "house_price.parquet")
+    )
+    arrow::write_parquet(
+      data.frame(
+        house_id = ids,
+        site_id = c(10L, 20L),
+        distance_m = c(100, 200)
+      ),
+      file.path(processed_dir, "spill_house_lookup.parquet")
+    )
+  } else {
+    zoopla_dir <- file.path(processed_dir, "zoopla")
+    dir.create(zoopla_dir, recursive = TRUE, showWarnings = FALSE)
+    arrow::write_parquet(
+      data.frame(
+        rental_id = ids,
+        listing_price = c(1000, 2000),
+        rented_est = as.POSIXct(
+          c("2021-01-01", "2022-01-01"), tz = "UTC"
+        ),
+        qtr_id = c(1, 5)
+      ),
+      file.path(zoopla_dir, "zoopla_rentals.parquet")
+    )
+    arrow::write_parquet(
+      data.frame(
+        rental_id = ids,
+        site_id = c(10L, 20L),
+        distance_m = c(100, 200)
+      ),
+      file.path(zoopla_dir, "spill_rental_lookup.parquet")
+    )
+  }
+}
+
+producer_specs <- list(
+  list(
+    file = "house_panel_within_radius.R",
+    market = "sales",
+    source_table = "house_price_data",
+    lookup_table = "spill_lookup",
+    id = "house_id",
+    processed_dir = function(root) root
+  ),
+  list(
+    file = "rental_panel_within_radius.R",
+    market = "rentals",
+    source_table = "rental_data",
+    lookup_table = "rental_spill_lookup",
+    id = "rental_id",
+    processed_dir = function(root) file.path(root, "zoopla")
+  ),
+  list(
+    file = "sale_panel_exp.R",
+    market = "sales",
+    source_table = "house_price_data",
+    lookup_table = "spill_lookup",
+    id = "house_id",
+    processed_dir = function(root) root
+  ),
+  list(
+    file = "rental_panel_exp.R",
+    market = "rentals",
+    source_table = "rental_data",
+    lookup_table = "rental_spill_lookup",
+    id = "rental_id",
+    processed_dir = function(root) root
+  )
+)
+
+for (spec in producer_specs) {
+  fixture_root <- tempfile(paste0("panel-refresh-", spec$market, "-"))
+  dir.create(fixture_root, recursive = TRUE)
+  on.exit(unlink(fixture_root, recursive = TRUE), add = TRUE)
+  write_fixture_inputs(fixture_root, spec$market, c("001", "alpha"))
+
+  env <- new.env(parent = globalenv())
+  sys.source(
+    here::here(
+      "scripts", "R", "06_analysis_datasets", spec$file
+    ),
+    envir = env
+  )
+  env$CONFIG$processed_dir <- spec$processed_dir(fixture_root)
+  env$CONFIG$db_path <- file.path(fixture_root, "fixture.duckdb")
+
+  configured_con <- env$connect_to_db()
+  configured_temp_dir <- DBI::dbGetQuery(
+    configured_con,
+    "SELECT value FROM duckdb_settings() WHERE name = 'temp_directory'"
+  )$value
+  DBI::dbDisconnect(configured_con, shutdown = TRUE)
+  expected_temp_dir <- file.path(fixture_root, "duckdb_temp")
+  assert_true(
+    dir.exists(expected_temp_dir) &&
+      identical(
+        normalizePath(configured_temp_dir, mustWork = TRUE),
+        normalizePath(expected_temp_dir, mustWork = TRUE)
+      ),
+    paste(spec$file, "must configure an existing, stable DuckDB spill directory.")
+  )
+
+  con <- DBI::dbConnect(duckdb::duckdb(), dbdir = ":memory:")
+  stale_ids <- stats::setNames(data.frame(1L), spec$id)
+  DBI::dbWriteTable(con, spec$source_table, stale_ids)
+  DBI::dbWriteTable(con, spec$lookup_table, stale_ids)
+  DBI::dbWriteTable(con, "unrelated_table", data.frame(value = 42L))
+
+  env$load_data_to_db(con)
+
+  source_ids <- DBI::dbGetQuery(
+    con,
+    paste0(
+      "SELECT ", DBI::dbQuoteIdentifier(con, spec$id),
+      " FROM ", DBI::dbQuoteIdentifier(con, spec$source_table),
+      " ORDER BY 1"
+    )
+  )[[spec$id]]
+  lookup_ids <- DBI::dbGetQuery(
+    con,
+    paste0(
+      "SELECT ", DBI::dbQuoteIdentifier(con, spec$id),
+      " FROM ", DBI::dbQuoteIdentifier(con, spec$lookup_table),
+      " ORDER BY 1"
+    )
+  )[[spec$id]]
+
+  assert_true(
+    identical(source_ids, c("001", "alpha")),
+    paste(spec$file, "must replace a stale source table with current utf8 IDs.")
+  )
+  assert_true(
+    identical(lookup_ids, c("001", "alpha")),
+    paste(spec$file, "must replace a stale lookup table with current utf8 IDs.")
+  )
+  assert_true(
+    identical(relation_type(con, spec$source_table), "VIEW") &&
+      identical(relation_type(con, spec$lookup_table), "VIEW"),
+    paste(spec$file, "must expose refreshed inputs as parquet-backed views.")
+  )
+  assert_true(
+    DBI::dbExistsTable(con, "unrelated_table") &&
+      identical(DBI::dbGetQuery(con, "SELECT value FROM unrelated_table")$value, 42L),
+    paste(spec$file, "must preserve unrelated persistent DuckDB tables.")
+  )
+
+  write_fixture_inputs(fixture_root, spec$market, c("009", "beta"))
+  env$load_data_to_db(con)
+  refreshed_ids <- DBI::dbGetQuery(
+    con,
+    paste0(
+      "SELECT ", DBI::dbQuoteIdentifier(con, spec$id),
+      " FROM ", DBI::dbQuoteIdentifier(con, spec$source_table),
+      " ORDER BY 1"
+    )
+  )[[spec$id]]
+  assert_true(
+    identical(refreshed_ids, c("009", "beta")),
+    paste(spec$file, "must refresh an existing parquet-backed view every run.")
+  )
+
+  if (grepl("within_radius", spec$file, fixed = TRUE)) {
+    prepared <- env$prepare_tables(con)
+    prepared_source <- if (identical(spec$market, "sales")) {
+      prepared$house_tbl
+    } else {
+      prepared$rental_tbl
+    }
+    period_probe <- tryCatch(
+      prepared_source |>
+        dplyr::select(dplyr::any_of(c("year", "month", "quarter"))) |>
+        utils::head(1L) |>
+        dplyr::collect(),
+      error = function(error) error
+    )
+    assert_true(
+      !inherits(period_probe, "error"),
+      paste(
+        spec$file,
+        "must derive periods from parquet timestamps without requiring DuckDB ICU.",
+        if (inherits(period_probe, "error")) conditionMessage(period_probe) else ""
+      )
+    )
+  }
+
+  DBI::dbDisconnect(con, shutdown = TRUE)
+}
+
+cat("All DuckDB panel refresh contract tests passed.\n")

--- a/scripts/R/testing/test_grid_long_difference_sales_contracts.R
+++ b/scripts/R/testing/test_grid_long_difference_sales_contracts.R
@@ -1,0 +1,70 @@
+# ==============================================================================
+# Grid Long-Difference Sales Contract Tests
+# ==============================================================================
+
+suppressPackageStartupMessages({
+  library(arrow)
+  library(data.table)
+  library(dplyr)
+  library(here)
+})
+
+source(here::here(
+  "scripts", "R", "06_analysis_datasets", "grid_long_difference_sales.R"
+))
+
+assert_true <- function(condition, message) {
+  if (!isTRUE(condition)) stop(message, call. = FALSE)
+}
+
+fixture_path <- tempfile(fileext = ".parquet")
+on.exit(unlink(fixture_path), add = TRUE)
+
+arrow::write_parquet(
+  data.frame(
+    house_id = c("001", "002", "003"),
+    site_id = c(10L, 20L, 30L),
+    distance_m = c(100, 250, 251),
+    unused_payload = c("a", "b", "c")
+  ),
+  fixture_path
+)
+
+query_at_collect <- NULL
+collect_spy <- function(query) {
+  query_at_collect <<- query
+  dplyr::collect(query)
+}
+
+result <- load_spill_lookup_within_radius(
+  fixture_path,
+  radius_m = 250,
+  collect_fn = collect_spy
+)
+
+assert_true(
+  inherits(query_at_collect, "arrow_dplyr_query"),
+  "The lookup must remain an Arrow lazy query until collect()."
+)
+assert_true(
+  identical(names(query_at_collect), c("house_id", "site_id", "distance_m")),
+  "Projection must be pushed into Arrow before collect()."
+)
+assert_true(
+  grepl(
+    "Filter: (distance_m <= 250)",
+    paste(capture.output(print(query_at_collect)), collapse = "\n"),
+    fixed = TRUE
+  ),
+  "The radius predicate must be pushed into Arrow before collect()."
+)
+assert_true(
+  identical(result$house_id, c("001", "002")),
+  "The lazy loader must retain character IDs, including leading zeroes."
+)
+assert_true(
+  identical(names(result), c("house_id", "site_id", "distance_m")),
+  "The collected lookup must expose only the required columns."
+)
+
+cat("All grid long-difference sales contract tests passed.\n")

--- a/scripts/R/testing/test_house_price_sewage_merge.Rmd
+++ b/scripts/R/testing/test_house_price_sewage_merge.Rmd
@@ -73,7 +73,7 @@ dat_mo <- dat$monthly
 ### Load House Price Data
 
 ```{r}
-house_price_data <- import(here("data", "processed", "house_price.parquet"),
+house_price_data <- import(here::here("data", "processed", "house_price.parquet"),
   trust = TRUE
 )
 spill_sites <- read_site_group_projection(
@@ -300,7 +300,7 @@ test_results <- test_chunk %>%
 ```{r}
 # --- Chunk Size Performance Test ---
 
-house_price_data <- import(here("data", "processed", "house_price.parquet"),
+house_price_data <- import(here::here("data", "processed", "house_price.parquet"),
   trust = TRUE
 )
 spill_sites <- read_site_group_projection(

--- a/scripts/R/testing/test_house_price_sewage_merge.Rmd
+++ b/scripts/R/testing/test_house_price_sewage_merge.Rmd
@@ -73,7 +73,7 @@ dat_mo <- dat$monthly
 ### Load House Price Data
 
 ```{r}
-house_price_data <- import(here("data", "processed", "house_price.rds"),
+house_price_data <- import(here("data", "processed", "house_price.parquet"),
   trust = TRUE
 )
 spill_sites <- read_site_group_projection(
@@ -106,10 +106,10 @@ spill_sites_sf <- spill_sites_sample %>%
 
 ```{r}
 houses_sf <- house_price_data %>%
+  mutate(year = lubridate::year(date_of_transfer)) %>%
   filter(!is.na(easting) & !is.na(northing)) %>%
-  mutate(house_id = row_number()) %>%
   st_as_sf(coords = c("easting", "northing"), crs = 27700) %>%
-  select(house_id, transaction_id, year, geometry)
+  select(house_id, year, geometry)
 ```
 
 ### Merge Data by Chunk
@@ -300,7 +300,7 @@ test_results <- test_chunk %>%
 ```{r}
 # --- Chunk Size Performance Test ---
 
-house_price_data <- import(here("data", "processed", "house_price.rds"),
+house_price_data <- import(here("data", "processed", "house_price.parquet"),
   trust = TRUE
 )
 spill_sites <- read_site_group_projection(
@@ -319,7 +319,6 @@ spill_sites_sf <- spill_sites %>%
 
 houses_sf <- house_price_data %>%
   filter(!is.na(easting) & !is.na(northing)) %>%
-  mutate(house_id = row_number()) %>%
   st_as_sf(coords = c("easting", "northing"), crs = 27700) %>%
   select(house_id, geometry)
 
@@ -481,7 +480,7 @@ CONFIG <- list(
 load_data <- function() {
   logger::log_info("Loading spatial datasets")
 
-  house_data <- rio::import(here::here("data", "processed", "house_price.rds"),
+  house_data <- rio::import(here::here("data", "processed", "house_price.parquet"),
     trust = TRUE
   )
   spill_data <- read_site_group_projection(
@@ -522,10 +521,10 @@ prepare_house_data <- function(house_data) {
   logger::log_info("Preparing house price spatial data")
 
   houses_sf <- house_data %>%
+    mutate(year = lubridate::year(date_of_transfer)) %>%
     filter(!is.na(easting) & !is.na(northing)) %>%
-    mutate(house_id = row_number()) %>%
     st_as_sf(coords = c("easting", "northing"), crs = 27700) %>%
-    select(house_id, any_of(c("transaction_id", "year")), geometry)
+    select(house_id, any_of("year"), geometry)
 
   return(houses_sf)
 }
@@ -576,7 +575,7 @@ perform_spatial_join <- function(houses_sf, spill_sites_sf, spill_lookup, radius
       ungroup() %>%
       st_drop_geometry() %>%
       select(
-        house_id, site_id, transaction_id, year,
+        house_id, site_id, year,
         distance_m, distance_km, n_site_groups
       )
   })

--- a/scripts/R/testing/test_lsoa_variation_updown_prior.R
+++ b/scripts/R/testing/test_lsoa_variation_updown_prior.R
@@ -12,8 +12,8 @@
 #
 # Samples:
 #   - Upstream/downstream prior sample:
-#       * sales: prior_to_sale/house_site + river-direction joins/filters
-#       * rentals: prior_to_rental/rental_site + river-direction joins/filters
+#       * sales: prior_to_sale_house_site + river-direction joins/filters
+#       * rentals: prior_to_rental_rental_site + river-direction joins/filters
 #       * exposure vars: upstream_count, downstream_count
 #   - Hedonic continuous prior sample:
 #       * sales: prior_to_sale
@@ -237,7 +237,7 @@ build_updown_prior_sales_sample <- function(area_var = "lsoa") {
   cat("Building upstream/downstream prior sales sample...\n")
 
   dat_cs_sales <- arrow::open_dataset(
-    here::here("data", "processed", "cross_section", "sales", "prior_to_sale", "house_site")
+    here::here("data", "processed", "cross_section", "sales", "prior_to_sale_house_site")
   ) |>
     filter(radius == RAD) |>
     collect()
@@ -247,7 +247,6 @@ build_updown_prior_sales_sample <- function(area_var = "lsoa") {
     trust = TRUE
   ) |>
     select(
-      -transaction_id,
       -date_of_transfer,
       -quality,
       -paon,
@@ -327,7 +326,7 @@ build_updown_prior_rentals_sample <- function(area_var = "lsoa") {
   cat("Building upstream/downstream prior rentals sample...\n")
 
   dat_cs_rentals <- arrow::open_dataset(
-    here::here("data", "processed", "cross_section", "rentals", "prior_to_rental", "rental_site")
+    here::here("data", "processed", "cross_section", "rentals", "prior_to_rental_rental_site")
   ) |>
     filter(radius == RAD) |>
     collect()
@@ -418,7 +417,6 @@ build_hedonic_prior_sales_sample <- function(area_var = "lsoa") {
     trust = TRUE
   ) |>
     select(
-      -transaction_id,
       -date_of_transfer,
       -quality,
       -paon,

--- a/scripts/R/testing/test_prior_exposure_contracts.R
+++ b/scripts/R/testing/test_prior_exposure_contracts.R
@@ -51,6 +51,48 @@ assert_error_contains <- function(expression, expected, message) {
   }
 }
 
+# The standalone ID-artifact verifier must prove exact referential integrity in
+# bounded Arrow batches without loading a large artifact's full ID column.
+match_rate_env <- new.env(parent = globalenv())
+sys.source(
+  here::here("scripts", "R", "testing", "verify_id_artifact_match_rates.R"),
+  envir = match_rate_env
+)
+match_rate_root <- tempfile("id-match-rate-contract-")
+dir.create(match_rate_root, recursive = TRUE)
+match_source_path <- file.path(match_rate_root, "source.parquet")
+match_good_path <- file.path(match_rate_root, "good.parquet")
+match_bad_path <- file.path(match_rate_root, "bad.parquet")
+arrow::write_parquet(
+  tibble(house_id = c("01leadingzero", "02stablehash")),
+  match_source_path
+)
+arrow::write_parquet(
+  tibble(house_id = c("01leadingzero", "01leadingzero", "02stablehash")),
+  match_good_path
+)
+arrow::write_parquet(
+  tibble(house_id = c("01leadingzero", "stale-id")),
+  match_bad_path
+)
+match_good <- match_rate_env$verify_id_artifact(
+  "fixture-good", match_good_path, "house_id",
+  match_rate_env$read_unique_source_ids(match_source_path, "house_id")
+)
+assert_identical(match_good$match_rate, 1, "The match-rate verifier must report exact 100% integrity.")
+assert_identical(match_good$id_type, "string", "The verifier must enforce utf8 artifact IDs.")
+assert_error_contains(
+  match_rate_env$verify_id_artifacts(
+    list(list(
+      name = "fixture-bad", artifact_path = match_bad_path,
+      source_path = match_source_path, id = "house_id"
+    )),
+    required_match_rate = 1
+  ),
+  "below required 100%",
+  "The standalone verifier must fail on one stale artifact ID."
+)
+
 expected_contract_failures <- character()
 record_expected_contract_failure <- function(label, expression) {
   tryCatch(
@@ -993,7 +1035,7 @@ for (label in names(producer_specs)) {
 
 variant_schema_signatures <- list(
   sale_site = c(
-    house_id = "int32", price = "int32", n_days_in_window = "int32",
+    house_id = "string", price = "int32", n_days_in_window = "int32",
     site_id = "int32", distance_m = "double", spill_hrs = "double",
     spill_count = "double", site_missing = "bool",
     spill_count_daily_avg = "double", spill_hrs_daily_avg = "double",
@@ -1001,7 +1043,7 @@ variant_schema_signatures <- list(
     radius = "int32"
   ),
   rental_site = c(
-    rental_id = "int32", listing_price = "double",
+    rental_id = "string", listing_price = "double",
     n_days_in_window = "int32", site_id = "int32", distance_m = "double",
     spill_hrs = "double", spill_count = "double", site_missing = "bool",
     spill_count_daily_avg = "double", spill_hrs_daily_avg = "double",
@@ -1009,7 +1051,7 @@ variant_schema_signatures <- list(
     radius = "int32"
   ),
   sale_radius = c(
-    house_id = "int32", price = "int32", n_days_in_window = "int32",
+    house_id = "string", price = "int32", n_days_in_window = "int32",
     spill_hrs = "double", n_spill_sites = "int32", spill_count = "double",
     mean_distance = "double", min_distance = "double",
     has_missing_site = "bool", spill_count_daily_avg = "double",
@@ -1017,7 +1059,7 @@ variant_schema_signatures <- list(
     spill_hrs_weekly_avg = "double", radius = "int32"
   ),
   rental_radius = c(
-    rental_id = "int32", listing_price = "double",
+    rental_id = "string", listing_price = "double",
     n_days_in_window = "int32", spill_hrs = "double",
     n_spill_sites = "int32", spill_count = "double", mean_distance = "double",
     min_distance = "double", has_missing_site = "bool",
@@ -1232,7 +1274,7 @@ rewrite_transaction_ids <- function(root, market, ids, value_name = NULL) {
   }
 }
 
-for (id_case in c("missing", "duplicate", "character")) {
+for (id_case in c("missing", "duplicate")) {
   for (label in names(producer_specs)) {
     spec <- producer_specs[[label]]
     market <- if (identical(spec$id, "house_id")) "sale" else "rental"
@@ -1242,8 +1284,7 @@ for (id_case in c("missing", "duplicate", "character")) {
     ids <- switch(
       id_case,
       missing = c(1L, NA_integer_),
-      duplicate = c(1L, 1L),
-      character = c("1", "2")
+      duplicate = c(1L, 1L)
     )
     rewrite_transaction_ids(id_root, market, ids)
     producer_env <- source_prior_exposure_producer(spec$path)
@@ -1263,6 +1304,28 @@ for (id_case in c("missing", "duplicate", "character")) {
       }
     )
   }
+}
+
+# Content-stable string IDs, including leading zeros, must survive loading.
+for (label in names(producer_specs)) {
+  spec <- producer_specs[[label]]
+  market <- if (identical(spec$id, "house_id")) "sale" else "rental"
+  id_root <- tempfile("prior-exposure-character-id-")
+  dir.create(id_root, recursive = TRUE)
+  write_eligibility_fixture(id_root, rep("2021-03-01 00:00:00", 2L))
+  leading_ids <- c("01leadingzero", "02stablehash")
+  rewrite_transaction_ids(id_root, market, leading_ids)
+  producer_env <- source_prior_exposure_producer(spec$path)
+  producer_env$CONFIG$processed_dir <- id_root
+  producer_env$CONFIG$site_group_crosswalk_path <- file.path(
+    id_root, "matched_events_annual_data", "site_group_crosswalk.parquet"
+  )
+  data <- producer_env$load_data()
+  assert_identical(
+    data$transaction_dt$transaction_id,
+    leading_ids,
+    paste(label, "must preserve character transaction IDs including leading zeros")
+  )
 }
 
 # Rental inputs must use the established value name, never a phantom `price`.
@@ -1428,26 +1491,26 @@ public_contract_candidate <- function(label) {
   candidate <- switch(
     label,
     sale_site = c(list(
-      house_id = rep(1L, 3L), price = rep(100000L, 3L),
+      house_id = rep("01leadingzero", 3L), price = rep(100000L, 3L),
       n_days_in_window = rep(60L, 3L), site_id = rep(10L, 3L),
       distance_m = rep(100, 3L), spill_hrs = c(0, 60, 120),
       spill_count = c(0, 30, 60), site_missing = rep(FALSE, 3L)
     ), common_rates),
     rental_site = c(list(
-      rental_id = rep(1L, 3L), listing_price = rep(1200, 3L),
+      rental_id = rep("01leadingzero", 3L), listing_price = rep(1200, 3L),
       n_days_in_window = rep(60L, 3L), site_id = rep(10L, 3L),
       distance_m = rep(100, 3L), spill_hrs = c(0, 60, 120),
       spill_count = c(0, 30, 60), site_missing = rep(FALSE, 3L)
     ), common_rates),
     sale_radius = c(list(
-      house_id = rep(1L, 3L), price = rep(100000L, 3L),
+      house_id = rep("01leadingzero", 3L), price = rep(100000L, 3L),
       n_days_in_window = rep(60L, 3L), spill_hrs = c(0, 60, 120),
       n_spill_sites = c(0L, 1L, 2L), spill_count = c(0, 30, 60),
       mean_distance = c(NA_real_, 100, 200), min_distance = c(NA_real_, 100, 100),
       has_missing_site = rep(FALSE, 3L)
     ), common_rates),
     rental_radius = c(list(
-      rental_id = rep(1L, 3L), listing_price = rep(1200, 3L),
+      rental_id = rep("01leadingzero", 3L), listing_price = rep(1200, 3L),
       n_days_in_window = rep(60L, 3L), spill_hrs = c(0, 60, 120),
       n_spill_sites = c(0L, 1L, 2L), spill_count = c(0, 30, 60),
       mean_distance = c(NA_real_, 100, 200), min_distance = c(NA_real_, 100, 100),
@@ -1470,13 +1533,10 @@ for (label in names(variant_schema_signatures)) {
     paste(label, "must reopen with its exact schema")
   )
 
-  character_identifier <- data.table::copy(candidate)
-  character_identifier[[names(candidate)[1]]] <- rep("1", nrow(candidate))
   drift_cases <- list(
     missing_field = candidate[, setdiff(names(candidate), "spill_hrs"), with = FALSE],
     extra_field = data.table::copy(candidate)[, unexpected := 1],
-    reordered_fields = candidate[, rev(names(candidate)), with = FALSE],
-    character_identifier = character_identifier
+    reordered_fields = candidate[, rev(names(candidate)), with = FALSE]
   )
   if (grepl("^rental", label)) {
     wrong_value <- data.table::copy(candidate)
@@ -1521,7 +1581,7 @@ for (label in names(variant_schema_signatures)) {
   )
 
   missing_id_candidate <- data.table::copy(candidate)
-  missing_id_candidate[1, (names(candidate)[1]) := NA_integer_]
+  missing_id_candidate[1, (names(candidate)[1]) := NA_character_]
   missing_id_path <- tempfile(paste0("prior-exposure-missing-id-", label, "-"))
   missing_id_error <- tryCatch(
     publish_prior_exposure_dataset(
@@ -1594,12 +1654,12 @@ for (label in names(producer_specs)) {
   )
   if (grepl("site$", label)) {
     assert_identical(
-      unique(result[[spec$id]]), 2L,
+      unique(result[[spec$id]]), "2",
       paste(label, "must preserve the populated chunk after an empty first chunk")
     )
   } else {
     assert_identical(
-      sort(unique(result[[spec$id]])), c(1L, 2L),
+      sort(unique(result[[spec$id]])), c("1", "2"),
       paste(label, "must preserve two same-radius chunk key sets without overwrite")
     )
     zero_rows <- result[get(spec$id) == 1L]

--- a/scripts/R/testing/test_prior_exposure_contracts.R
+++ b/scripts/R/testing/test_prior_exposure_contracts.R
@@ -132,14 +132,14 @@ write_rental_fixture <- function(root) {
 
   arrow::write_parquet(
     tibble(
-      rental_id = 1L,
+      rental_id = "001",
       listing_price = 1200,
       rented_est = as.Date("2024-03-15")
     ),
     file.path(zoopla_dir, "zoopla_rentals.parquet")
   )
   arrow::write_parquet(
-    tibble(rental_id = 1L, site_id = 10L, distance_m = 100),
+    tibble(rental_id = "001", site_id = 10L, distance_m = 100),
     file.path(zoopla_dir, "spill_rental_lookup.parquet")
   )
   arrow::write_parquet(
@@ -197,7 +197,7 @@ assert_rental_time_contract <- function(producer_env, fixture_root, label) {
     paste(label, "must preserve rental Date as UTC midnight")
   )
 
-  joined <- producer_env$create_joined_events(1L, data)
+  joined <- producer_env$create_joined_events("001", data)
   assert_identical(
     nrow(joined$events_dt),
     1L,
@@ -431,34 +431,35 @@ write_prefix_fixture <- function(root, transaction_times) {
   dir.create(zoopla_dir, recursive = TRUE, showWarnings = FALSE)
   dir.create(event_dir, recursive = TRUE, showWarnings = FALSE)
 
-  transaction_ids <- seq_along(transaction_times)
+  transaction_positions <- seq_along(transaction_times)
+  transaction_ids <- sprintf("%03d", transaction_positions)
   transaction_times <- as.POSIXct(transaction_times, tz = "UTC")
   arrow::write_parquet(
     tibble(
-      house_id = as.integer(transaction_ids),
-      price = as.double(transaction_ids * 100000),
+      house_id = transaction_ids,
+      price = as.double(transaction_positions * 100000),
       date_of_transfer = transaction_times
     ),
     file.path(root, "house_price.parquet")
   )
   arrow::write_parquet(
     tibble(
-      rental_id = as.integer(transaction_ids),
-      listing_price = as.double(transaction_ids * 1000),
+      rental_id = transaction_ids,
+      listing_price = as.double(transaction_positions * 1000),
       rented_est = as.Date(transaction_times)
     ),
     file.path(zoopla_dir, "zoopla_rentals.parquet")
   )
 
   lookup_rows <- tibble(
-    transaction_id = c(transaction_ids, 2L, 2L),
+    transaction_id = c(transaction_ids, "002", "002"),
     site_id = c(rep(10L, length(transaction_ids)), 20L, 30L),
     distance_m = c(rep(100, length(transaction_ids)), 400, 700)
   )
   arrow::write_parquet(
     transmute(
       lookup_rows,
-      house_id = as.integer(.data$transaction_id),
+      house_id = .data$transaction_id,
       site_id = as.integer(.data$site_id),
       distance_m = as.double(.data$distance_m)
     ),
@@ -467,7 +468,7 @@ write_prefix_fixture <- function(root, transaction_times) {
   arrow::write_parquet(
     transmute(
       lookup_rows,
-      rental_id = as.integer(.data$transaction_id),
+      rental_id = .data$transaction_id,
       site_id = as.integer(.data$site_id),
       distance_m = as.double(.data$distance_m)
     ),
@@ -580,7 +581,7 @@ write_evidence_output_fixture <- function(root) {
   )
   arrow::write_parquet(
     tibble(
-      house_id = 1:2,
+      house_id = c("001", "002"),
       price = c(100000L, 200000L),
       date_of_transfer = transaction_times
     ),
@@ -588,19 +589,19 @@ write_evidence_output_fixture <- function(root) {
   )
   arrow::write_parquet(
     tibble(
-      rental_id = 1:2,
+      rental_id = c("001", "002"),
       listing_price = c(1000, 2000),
       rented_est = as.Date(transaction_times)
     ),
     file.path(zoopla_dir, "zoopla_rentals.parquet")
   )
 
-  lookup <- tidyr::expand_grid(transaction_id = 1:2, site_id = 10:15) |>
+  lookup <- tidyr::expand_grid(transaction_id = c("001", "002"), site_id = 10:15) |>
     mutate(distance_m = 100)
   arrow::write_parquet(
     transmute(
       lookup,
-      house_id = as.integer(.data$transaction_id),
+      house_id = .data$transaction_id,
       site_id = as.integer(.data$site_id),
       distance_m = as.double(.data$distance_m)
     ),
@@ -609,7 +610,7 @@ write_evidence_output_fixture <- function(root) {
   arrow::write_parquet(
     transmute(
       lookup,
-      rental_id = as.integer(.data$transaction_id),
+      rental_id = .data$transaction_id,
       site_id = as.integer(.data$site_id),
       distance_m = as.double(.data$distance_m)
     ),
@@ -684,18 +685,18 @@ for (label in c("sale_site", "rental_site")) {
   )
   all_metrics <- c(raw_metrics, rate_metrics)
   assert_true(
-    all(result[get(spec$id) == 1L, !is.na(spill_count)]),
+    all(result[get(spec$id) == "001", !is.na(spill_count)]),
     paste(label, "must not let a future 2023 evidence gap mask a 2022 cutoff")
   )
   assert_true(
-    all(result[get(spec$id) == 2L & site_id == 10L, spill_count] == 0),
+    all(result[get(spec$id) == "002" & site_id == 10L, spill_count] == 0),
     paste(label, "must retain reported_zero without events as observed zero")
   )
   assert_true(
-    all(result[get(spec$id) == 2L & site_id %in% c(11L, 12L), spill_count] == 1),
+    all(result[get(spec$id) == "002" & site_id %in% c(11L, 12L), spill_count] == 1),
     paste(label, "must use detailed events for event-bearing zero and positive years")
   )
-  unknown_rows <- result[get(spec$id) == 2L & site_id %in% c(13L, 14L, 15L)]
+  unknown_rows <- result[get(spec$id) == "002" & site_id %in% c(13L, 14L, 15L)]
   assert_true(
     all(vapply(unknown_rows[, ..all_metrics], function(column) all(is.na(column)), logical(1))),
     paste(label, "must keep all six final metrics unknown after zero-fill and rate calculation")
@@ -915,9 +916,9 @@ for (label in names(producer_specs)) {
     paste(label, "must keep early prefixes observed and propagate the later gap")
   )
 
-  joined <- producer_env$create_joined_events(1:4, data)
+  joined <- producer_env$create_joined_events(sprintf("%03d", 1:4), data)
   expected_pairs <- data$spill_lookup_dt[
-    get(spec$id) %in% 1:4,
+    get(spec$id) %in% sprintf("%03d", 1:4),
     c(spec$id, "site_id", "distance_m"),
     with = FALSE
   ]
@@ -956,12 +957,12 @@ for (label in names(producer_specs)) {
   }
   expected_types <- if (grepl("site$", label)) {
     c(
-      "integer", "double", "integer", "integer", "double", "double",
+      "character", "double", "integer", "integer", "double", "double",
       "double", "double", "logical", rep("double", 4L)
     )
   } else {
     c(
-      "integer", "double", "integer", "double", "double", "integer",
+      "character", "double", "integer", "double", "double", "integer",
       "double", "double", "double", "logical", rep("double", 4L)
     )
   }
@@ -981,25 +982,25 @@ for (label in names(producer_specs)) {
   )
   if (grepl("site$", label)) {
     assert_true(
-      all(!result[get(spec$id) == 2L & site_id == 10L, get(spec$missing)]),
+      all(!result[get(spec$id) == "002" & site_id == 10L, get(spec$missing)]),
       paste(label, "must not let the future 2023 gap mask a 2022 transaction")
     )
     assert_true(
-      all(result[get(spec$id) == 3L & site_id == 10L, get(spec$missing)]),
+      all(result[get(spec$id) == "003" & site_id == 10L, get(spec$missing)]),
       paste(label, "must mark a 2024 transaction after the 2023 gap")
     )
     assert_true(
-      all(result[get(spec$id) == 2L & site_id == 20L, get(spec$missing)]),
+      all(result[get(spec$id) == "002" & site_id == 20L, get(spec$missing)]),
       paste(label, "must conservatively mark an entirely absent Site Group")
     )
   } else {
     assert_true(
-      !result[get(spec$id) == 2L & radius == 250, get(spec$missing)],
+      !result[get(spec$id) == "002" & radius == 250, get(spec$missing)],
       paste(label, "must keep missingness outside 250m from invalidating 250m")
     )
     assert_true(
-      result[get(spec$id) == 2L & radius == 500, get(spec$missing)] &&
-        result[get(spec$id) == 2L & radius == 1000, get(spec$missing)],
+      result[get(spec$id) == "002" & radius == 500, get(spec$missing)] &&
+        result[get(spec$id) == "002" & radius == 1000, get(spec$missing)],
       paste(label, "must propagate missingness only through containing radii")
     )
   }
@@ -1122,29 +1123,30 @@ write_eligibility_fixture <- function(root, transaction_times) {
   dir.create(event_dir, recursive = TRUE, showWarnings = FALSE)
 
   transaction_times <- as.POSIXct(transaction_times, tz = "UTC")
-  transaction_ids <- seq_along(transaction_times)
+  transaction_positions <- seq_along(transaction_times)
+  transaction_ids <- sprintf("%03d", transaction_positions)
   arrow::write_parquet(
     tibble(
-      house_id = as.integer(transaction_ids),
-      price = as.integer(transaction_ids * 100000),
+      house_id = transaction_ids,
+      price = as.integer(transaction_positions * 100000),
       date_of_transfer = transaction_times
     ),
     file.path(root, "house_price.parquet")
   )
   arrow::write_parquet(
     tibble(
-      rental_id = as.integer(transaction_ids),
-      listing_price = as.double(transaction_ids * 1000),
+      rental_id = transaction_ids,
+      listing_price = as.double(transaction_positions * 1000),
       rented_est = transaction_times
     ),
     file.path(zoopla_dir, "zoopla_rentals.parquet")
   )
   arrow::write_parquet(
-    tibble(house_id = integer(), site_id = integer(), distance_m = double()),
+    tibble(house_id = character(), site_id = integer(), distance_m = double()),
     file.path(root, "spill_house_lookup.parquet")
   )
   arrow::write_parquet(
-    tibble(rental_id = integer(), site_id = integer(), distance_m = double()),
+    tibble(rental_id = character(), site_id = integer(), distance_m = double()),
     file.path(zoopla_dir, "spill_rental_lookup.parquet")
   )
   arrow::write_parquet(
@@ -1195,7 +1197,7 @@ for (label in names(producer_specs)) {
     {
       assert_identical(
         metadata[[spec$id]],
-        2L,
+        "002",
         paste(label, "must exclude 29d23h59m and retain exactly 30 complete days")
       )
       assert_identical(
@@ -1274,7 +1276,7 @@ rewrite_transaction_ids <- function(root, market, ids, value_name = NULL) {
   }
 }
 
-for (id_case in c("missing", "duplicate")) {
+for (id_case in c("missing", "duplicate", "numeric")) {
   for (label in names(producer_specs)) {
     spec <- producer_specs[[label]]
     market <- if (identical(spec$id, "house_id")) "sale" else "rental"
@@ -1283,8 +1285,9 @@ for (id_case in c("missing", "duplicate")) {
     write_eligibility_fixture(id_root, rep("2021-03-01 00:00:00", 2L))
     ids <- switch(
       id_case,
-      missing = c(1L, NA_integer_),
-      duplicate = c(1L, 1L)
+      missing = c("001", NA_character_),
+      duplicate = c("001", "001"),
+      numeric = 1:2
     )
     rewrite_transaction_ids(id_root, market, ids)
     producer_env <- source_prior_exposure_producer(spec$path)
@@ -1332,7 +1335,7 @@ for (label in names(producer_specs)) {
 wrong_rental_value_root <- tempfile("prior-exposure-rental-value-")
 dir.create(wrong_rental_value_root, recursive = TRUE)
 write_eligibility_fixture(wrong_rental_value_root, "2021-03-01 00:00:00")
-rewrite_transaction_ids(wrong_rental_value_root, "rental", 1L, value_name = "price")
+rewrite_transaction_ids(wrong_rental_value_root, "rental", "001", value_name = "price")
 for (label in c("rental_site", "rental_radius")) {
   spec <- producer_specs[[label]]
   producer_env <- source_prior_exposure_producer(spec$path)
@@ -1355,11 +1358,11 @@ write_eligibility_fixture(
   c("2021-03-01 00:00:00", "2021-03-02 00:00:00")
 )
 arrow::write_parquet(
-  tibble(house_id = 2L, site_id = 10L, distance_m = 100),
+  tibble(house_id = "002", site_id = 10L, distance_m = 100),
   file.path(empty_then_populated_root, "spill_house_lookup.parquet")
 )
 arrow::write_parquet(
-  tibble(rental_id = 2L, site_id = 10L, distance_m = 100),
+  tibble(rental_id = "002", site_id = 10L, distance_m = 100),
   file.path(empty_then_populated_root, "zoopla", "spill_rental_lookup.parquet")
 )
 for (label in c("sale_site", "rental_site")) {
@@ -1370,8 +1373,8 @@ for (label in c("sale_site", "rental_site")) {
     empty_then_populated_root, "matched_events_annual_data", "site_group_crosswalk.parquet"
   )
   data <- producer_env$load_data()
-  empty_chunk <- producer_env$process_chunk(1L, data)
-  populated_chunk <- producer_env$process_chunk(2L, data)
+  empty_chunk <- producer_env$process_chunk("001", data)
+  populated_chunk <- producer_env$process_chunk("002", data)
   record_expected_contract_failure(
     paste(label, "typed empty site chunk"),
     {
@@ -1401,7 +1404,7 @@ for (label in c("sale_radius", "rental_radius")) {
   producer_env$CONFIG$chunk_size <- 1L
   data <- producer_env$load_data()
   result <- collect_prior_exposure_fixture(producer_env, data)
-  empty_rows <- result[get(spec$id) == 1L]
+  empty_rows <- result[get(spec$id) == "001"]
   assert_identical(
     empty_rows$radius,
     c(250L, 500L, 1000L),
@@ -1423,7 +1426,7 @@ for (label in c("sale_radius", "rental_radius")) {
 # is observably different from summing an expanded radius table for large and
 # small floating-point values, despite being mathematically equivalent.
 accumulation_fixture <- data.table(
-  transaction_id = rep(1L, 3L),
+  transaction_id = rep("001", 3L),
   site_id = 1:3,
   distance_m = c(300, 100, 200),
   site_missing = FALSE,
@@ -1432,7 +1435,7 @@ accumulation_fixture <- data.table(
   spill_count = c(1, 1, 1)
 )
 accumulation_result <- prior_exposure_reduce_radius(
-  accumulation_fixture, 1L, 500
+  accumulation_fixture, "001", 500
 )
 assert_identical(
   accumulation_result$spill_hrs,
@@ -1442,11 +1445,11 @@ assert_identical(
 
 stable_contract <- prior_exposure_variant("sale", "radius")
 stable_lookup <- data.table(
-  transaction_id = c(1L, 2L), site_id = c(10L, 10L), distance_m = 100,
+  transaction_id = c("001", "002"), site_id = c(10L, 10L), distance_m = 100,
   site_missing = FALSE, has_unknown_event_evidence = FALSE
 )
 stable_events <- data.table(
-  house_id = c(2L, 1L, 1L), site_id = 10L,
+  house_id = c("002", "001", "001"), site_id = 10L,
   start_time = as.POSIXct(c(
     "2021-01-01 03:00:00", "2021-01-01 02:00:00", "2021-01-01 01:00:00"
   ), tz = "UTC"),
@@ -1464,11 +1467,11 @@ stable_events <- data.table(
 stable_full <- prior_exposure_transaction_site_metrics(
   list(internal_lookup = stable_lookup, events_dt = stable_events),
   stable_contract
-)[transaction_id == 1L]
+)[transaction_id == "001"]
 stable_isolated <- prior_exposure_transaction_site_metrics(
   list(
-    internal_lookup = stable_lookup[transaction_id == 1L],
-    events_dt = stable_events[house_id == 1L][2:1]
+    internal_lookup = stable_lookup[transaction_id == "001"],
+    events_dt = stable_events[house_id == "001"][2:1]
   ),
   stable_contract
 )
@@ -1654,12 +1657,12 @@ for (label in names(producer_specs)) {
   )
   if (grepl("site$", label)) {
     assert_identical(
-      unique(result[[spec$id]]), "2",
+      unique(result[[spec$id]]), "002",
       paste(label, "must preserve the populated chunk after an empty first chunk")
     )
   } else {
     assert_identical(
-      sort(unique(result[[spec$id]])), c("1", "2"),
+      sort(unique(result[[spec$id]])), c("001", "002"),
       paste(label, "must preserve two same-radius chunk key sets without overwrite")
     )
     zero_rows <- result[get(spec$id) == 1L]
@@ -1738,7 +1741,7 @@ observing_first_write <- function(chunk, stage_path, chunk_index) {
   prior_exposure_write_chunk(chunk, stage_path, chunk_index)
 }
 fail_second_chunk <- function(transaction_ids, data, joined) {
-  if (identical(transaction_ids, 2L)) stop("injected second-chunk failure", call. = FALSE)
+  if (identical(transaction_ids, "002")) stop("injected second-chunk failure", call. = FALSE)
   prior_exposure_process_joined_chunk(transaction_ids, data, joined)
 }
 unreached_publisher <- function(...) {

--- a/scripts/R/testing/test_property_site_match_contracts.R
+++ b/scripts/R/testing/test_property_site_match_contracts.R
@@ -107,7 +107,7 @@ site_fixture <- tibble(
 )
 
 property_fixture <- tibble(
-  property_id = 1:5,
+  property_id = c("001", "0abc", "deadbeef00000001", "004", "005"),
   easting = c(500001, 510000, 510100, 500000, 600000),
   northing = c(200000, 200000, 200000, 205000, 300000)
 )
@@ -199,19 +199,19 @@ for (producer_name in names(producer_specs)) {
   result <- run_match(spec)
 
   assert_true(
-    any(result[[id_column]] == 1L & result$site_id == 101L),
+    any(result[[id_column]] == "001" & result$site_id == 101L),
     paste(producer_name, "must match a property inside 10 km.")
   )
   assert_true(
-    any(result[[id_column]] == 2L & result$site_id == 101L),
+    any(result[[id_column]] == "0abc" & result$site_id == 101L),
     paste(producer_name, "must include a property exactly 10 km away.")
   )
   assert_true(
-    !any(result[[id_column]] == 3L & result$site_id == 101L, na.rm = TRUE),
+    !any(result[[id_column]] == "deadbeef00000001" & result$site_id == 101L, na.rm = TRUE),
     paste(producer_name, "must exclude a property beyond 10 km.")
   )
 
-  multi_match <- result |> filter(.data[[id_column]] == 4L)
+  multi_match <- result |> filter(.data[[id_column]] == "004")
   assert_identical(
     multi_match$site_id,
     c(101L, 202L),
@@ -227,7 +227,7 @@ for (producer_name in names(producer_specs)) {
     paste(producer_name, "must produce unique property-Site Group keys.")
   )
 
-  unmatched <- result |> filter(.data[[id_column]] == 5L)
+  unmatched <- result |> filter(.data[[id_column]] == "005")
   assert_identical(
     nrow(unmatched),
     1L,
@@ -241,7 +241,7 @@ for (producer_name in names(producer_specs)) {
   assert_identical(
     vapply(result, typeof, character(1)),
     setNames(
-      c("integer", "integer", "double", "double", "integer"),
+      c("character", "integer", "double", "double", "integer"),
       c(id_column, "site_id", "distance_m", "distance_km", "n_site_groups")
     ),
     paste(producer_name, "must preserve the five-column lookup types.")
@@ -482,7 +482,7 @@ audit_production_artifact <- function(producer_name, spec, expected_radius_km = 
     is.finite(properties$easting) &
     is.finite(properties$northing)
   eligible_properties <- properties[coordinate_eligible, , drop = FALSE]
-  eligible_ids <- as.integer(eligible_properties[[id_column]])
+  eligible_ids <- eligible_properties[[id_column]]
   assert_true(
     length(eligible_ids) > 0L,
     paste(producer_name, "production input must contain eligible properties.")

--- a/scripts/R/testing/test_property_site_match_contracts.R
+++ b/scripts/R/testing/test_property_site_match_contracts.R
@@ -135,7 +135,9 @@ run_stream <- function(spec, properties = property_fixture, chunk_size = 2L,
                        output_path = tempfile(fileext = ".parquet"),
                        fail_at = NULL,
                        close_writer = function(writer) writer$Close(),
-                       promote_stage = function(from, to) file.rename(from, to)) {
+                       promote_stage = function(from, to) file.rename(from, to),
+                       settle_publication = function(verify, output_path,
+                                                     stage_path) verify()) {
   names(properties)[names(properties) == "property_id"] <- spec$id_column
   data <- setNames(list(properties), spec$data_key)
   data$spill <- site_fixture
@@ -146,7 +148,8 @@ run_stream <- function(spec, properties = property_fixture, chunk_size = 2L,
     chunk_size = chunk_size,
     fail_at = fail_at,
     close_writer = close_writer,
-    promote_stage = promote_stage
+    promote_stage = promote_stage,
+    settle_publication = settle_publication
   )
   output_path
 }
@@ -301,7 +304,8 @@ for (producer_name in names(producer_specs)) {
     }),
     validation = list(fail_at = "validation"),
     sample_oracle = list(fail_at = "sample_oracle"),
-    promotion = list(promote_stage = function(from, to) FALSE)
+    promotion = list(promote_stage = function(from, to) FALSE),
+    promotion_false_success = list(promote_stage = function(from, to) TRUE)
   )
   for (failure_point in names(failure_cases)) {
     failure <- tryCatch(
@@ -338,6 +342,42 @@ for (producer_name in names(producer_specs)) {
       paste(producer_name, "must clean its stage after", failure_point)
     )
   }
+
+  delayed_reversion_path <- tempfile(
+    paste0(producer_name, "-delayed-reversion-"),
+    fileext = ".parquet"
+  )
+  delayed_reversion <- tryCatch(
+    run_stream(
+      spec,
+      chunk_size = 2L,
+      output_path = delayed_reversion_path,
+      settle_publication = function(verify, output_path, stage_path) {
+        verify()
+        assert_true(
+          file.rename(output_path, stage_path),
+          "Delayed-reversion fixture must restore the stage path."
+        )
+        verify()
+      }
+    ),
+    error = identity
+  )
+  assert_true(
+    inherits(delayed_reversion, "error"),
+    paste(producer_name, "must reject a delayed post-promotion reversion.")
+  )
+  assert_true(
+    !file.exists(delayed_reversion_path),
+    paste(producer_name, "must not leave a canonical after delayed reversion.")
+  )
+  delayed_stages <- stage_siblings(delayed_reversion_path)
+  assert_identical(
+    length(delayed_stages),
+    1L,
+    paste(producer_name, "must preserve the validated stage after delayed reversion.")
+  )
+  unlink(delayed_stages)
 
   diagnostic_properties <- tibble(
     property_id = 1:4,

--- a/scripts/R/testing/test_repeat_transactions_contracts.R
+++ b/scripts/R/testing/test_repeat_transactions_contracts.R
@@ -75,7 +75,7 @@ make_config <- function(name = "base", coverage_floor = 0) {
     price_ratio_review_path = file.path(test_dir, paste0(name, "-ratios.parquet")),
     same_day_review_path = file.path(test_dir, paste0(name, "-same-day.parquet")),
     market = "sales",
-    log_name = paste0("repeat-contract-", name),
+    log_file = file.path(test_dir, paste0(name, ".log")),
     year_min = 2014L,
     year_max = 2024L,
     key_coverage_floor = coverage_floor,
@@ -128,6 +128,26 @@ assert_error_matching(
   serialize_hash_fields(reserved_input, "value"),
   "reserved",
   "Hash serialization must reject reserved tokens in source fields."
+)
+
+# Numeric serialization must depend on the row alone, never on its batch.
+mixed_batch <- serialize_hash_fields(data.frame(p = c(1200, 1300.5)), "p")
+assert_identical(
+  mixed_batch[[1]],
+  serialize_hash_fields(data.frame(p = 1200), "p"),
+  "A whole-valued numeric must serialize identically beside a fractional value."
+)
+assert_identical(
+  mixed_batch[[2]],
+  serialize_hash_fields(data.frame(p = 1300.5), "p"),
+  "A fractional numeric must serialize identically beside a whole value."
+)
+fractional_hash_input <- copy(hash_input)
+fractional_hash_input[2, listing_price := 1300.5]
+assert_identical(
+  hash_rental_identity(fractional_hash_input)[[1]],
+  hash_rental_identity(fractional_hash_input[1]),
+  "A rental identity hash must be recomputable from its own row alone."
 )
 
 # Happy path, punctuation normalization, missing-component handling, and singles.

--- a/scripts/R/testing/test_repeat_transactions_contracts.R
+++ b/scripts/R/testing/test_repeat_transactions_contracts.R
@@ -73,6 +73,7 @@ make_config <- function(name = "base", coverage_floor = 0) {
     output_path = file.path(test_dir, paste0(name, "-mapping.parquet")),
     large_group_review_path = file.path(test_dir, paste0(name, "-large.parquet")),
     price_ratio_review_path = file.path(test_dir, paste0(name, "-ratios.parquet")),
+    same_day_review_path = file.path(test_dir, paste0(name, "-same-day.parquet")),
     market = "sales",
     log_name = paste0("repeat-contract-", name),
     year_min = 2014L,
@@ -239,6 +240,104 @@ mixed_result <- withCallingHandlers(
 assert_true(any(grepl("property type", warnings, ignore.case = TRUE)), "Mixed property types must warn rather than fail.")
 assert_identical(nrow(mixed_result$mapping), 3L, "Warn-only diagnostics must not remove mapped rows.")
 
+# Holding periods are measured in days for every supported date type. A same-day
+# pair drives difftime's auto-selected unit to seconds for the whole vector, which
+# silently collapsed every annualized ratio toward one on the POSIXct sales input.
+posix_keyed <- data.table(
+  address_key = c("K1", "K1", "K2", "K2"),
+  house_id = c("posix-01", "posix-02", "posix-03", "posix-04"),
+  date_of_transfer = as.POSIXct(
+    c("2022-01-01", "2022-06-01", "2023-01-01", "2023-01-01"),
+    tz = "UTC"
+  ),
+  price = c(100000, 200000, 300000, 300000)
+)
+posix_ratios <- build_price_ratio_review(posix_keyed, make_config("posix"))
+assert_identical(
+  nrow(posix_ratios), 1L,
+  "A doubling over 151 days must be flagged even when a same-day pair is present."
+)
+assert_identical(
+  posix_ratios$holding_days, 151,
+  "holding_days must be measured in days, never in difftime's auto-selected unit."
+)
+assert_true(
+  inherits(posix_ratios$date_of_transfer, "Date"),
+  "Review dates must normalize to Date so both markets share one review schema."
+)
+
+# Two transactions at one address on one date are data errors. Every conflicting
+# row leaves the mapping, and repeat_count is counted only over the survivors.
+same_day_fixture <- rbind(
+  fixture,
+  data.table(
+    house_id = "05mno", postcode = "SW1A 1AA", paon = "10",
+    saon = NA_character_, street = "ST JOHNS ROAD",
+    date_of_transfer = as.Date("2022-01-01"), price = 130000,
+    property_type = "T"
+  )
+)
+same_day_result <- build_repeat_mapping(same_day_fixture, make_config("same-day"))
+assert_identical(
+  nrow(same_day_result$mapping), 2L,
+  "Both rows of a same-day conflict must leave the mapping."
+)
+assert_true(
+  !any(c("02def", "05mno") %in% same_day_result$mapping$house_id),
+  "Neither side of a same-day conflict may survive; these are not deduplications."
+)
+assert_identical(
+  same_day_result$metrics$same_day_excluded_count, 2L,
+  "Same-day exclusions must be counted."
+)
+assert_identical(
+  same_day_result$metrics$mapped_count, 2L,
+  "mapped_count must report the rows that actually reach the mapping."
+)
+assert_identical(
+  same_day_result$metrics$keyed_count, 4L,
+  "keyed_count must keep meaning address-key completeness, before same-day exclusion."
+)
+assert_identical(
+  same_day_result$metrics$key_coverage, 1,
+  "Same-day exclusion must not be folded into address-key coverage."
+)
+assert_true(
+  all(same_day_result$mapping$repeat_count == 1L),
+  "repeat_count must be computed after exclusion, leaving the 2018 sale a single."
+)
+
+# The excluded rows are retained for audit rather than silently dropped.
+assert_identical(
+  nrow(same_day_result$same_day_conflicts), 2L,
+  "Every excluded row must be routed to the same-day review table."
+)
+assert_identical(
+  sort(same_day_result$same_day_conflicts$house_id), c("02def", "05mno"),
+  "The same-day review must name both conflicting transactions."
+)
+assert_identical(
+  names(same_day_result$same_day_conflicts),
+  c("house_id", "address_key", "date_of_transfer", "price", "same_day_group_size"),
+  "The same-day review must carry enough context to adjudicate the conflict."
+)
+assert_true(
+  all(same_day_result$same_day_conflicts$same_day_group_size == 2L),
+  "The same-day review must record how many transactions shared the date."
+)
+same_day_warnings <- character()
+invisible(withCallingHandlers(
+  build_repeat_mapping(same_day_fixture, make_config("same-day-warn")),
+  warning = function(w) {
+    same_day_warnings <<- c(same_day_warnings, conditionMessage(w))
+    invokeRestart("muffleWarning")
+  }
+))
+assert_true(
+  any(grepl("same-day", same_day_warnings, ignore.case = TRUE)),
+  "Same-day exclusions must warn so the run log records them."
+)
+
 # Arrow integration: literal schema, review files, manifest round-trip, and first-generation log.
 logs <- character()
 integration_config <- make_config("integration")
@@ -251,6 +350,7 @@ assert_true(any(grepl("first generation", logs, ignore.case = TRUE)), "The first
 assert_true(file.exists(integration_config$output_path), "The mapping parquet must be written.")
 assert_true(file.exists(integration_config$large_group_review_path), "The large-group review parquet must be written even when empty.")
 assert_true(file.exists(integration_config$price_ratio_review_path), "The price-ratio review parquet must be written even when empty.")
+assert_true(file.exists(integration_config$same_day_review_path), "The same-day review parquet must be written even when empty.")
 
 written <- arrow::read_parquet(integration_config$output_path, as_data_frame = FALSE)
 assert_identical(names(written), c("house_id", "repeat_id", "repeat_count"), "The mapping must have exactly the declared three columns.")
@@ -262,13 +362,16 @@ manifest <- written$metadata
 expected_manifest_keys <- c(
   "repeat_manifest_version", "input_path", "input_row_count", "input_mtime",
   "run_timestamp", "keyed_count", "excluded_count", "key_coverage",
-  "repeat_share", "largest_group_size", "market", "repeat_count_semantics"
+  "repeat_share", "largest_group_size", "market", "repeat_count_semantics",
+  "mapped_count", "same_day_excluded_count"
 )
 assert_true(all(expected_manifest_keys %in% names(manifest)), "Every required manifest key must round-trip through Arrow metadata.")
 assert_identical(manifest$input_path, normalizePath(integration_config$input_path), "Manifest input_path must identify the production-read source.")
 assert_identical(manifest$input_row_count, "3", "Manifest input row count must round-trip as text.")
 assert_identical(manifest$keyed_count, "3", "Manifest keyed count must round-trip as text.")
 assert_identical(manifest$excluded_count, "0", "Manifest excluded count must round-trip as text.")
+assert_identical(manifest$mapped_count, "3", "Manifest mapped count must round-trip as text.")
+assert_identical(manifest$same_day_excluded_count, "0", "Manifest same-day exclusion count must round-trip as text.")
 
 rerun_logs <- character()
 run_repeat_transactions(
@@ -276,6 +379,28 @@ run_repeat_transactions(
   log_fn = function(level, message) rerun_logs <<- c(rerun_logs, paste(level, message))
 )
 assert_true(any(grepl("manifest delta", rerun_logs, ignore.case = TRUE)), "A compatible prior manifest must produce a logged delta.")
+
+# A manifest written before a metric existed must still diff, without shifting
+# the remaining field pairs out of alignment.
+legacy_fields <- list(
+  market = "sales", input_row_count = "10", keyed_count = "9",
+  excluded_count = "1", key_coverage = "0.90000000",
+  repeat_share = "0.50000000", largest_group_size = "3"
+)
+legacy_delta_logs <- character()
+log_manifest_delta(
+  previous = legacy_fields,
+  current = c(legacy_fields, list(mapped_count = "8", same_day_excluded_count = "1")),
+  log_fn = function(level, message) legacy_delta_logs <<- c(legacy_delta_logs, message)
+)
+assert_true(
+  any(grepl("largest_group_size=3->3", legacy_delta_logs, fixed = TRUE)),
+  "Fields absent from an older manifest must not shift the remaining delta pairs."
+)
+assert_true(
+  any(grepl("same_day_excluded_count=", legacy_delta_logs, fixed = TRUE)),
+  "New metrics must appear in the delta even when the previous manifest lacks them."
+)
 
 corrupt_manifest_path <- file.path(test_dir, "corrupt-previous.parquet")
 writeBin(charToRaw("not parquet"), corrupt_manifest_path)

--- a/scripts/R/testing/test_repeat_transactions_contracts.R
+++ b/scripts/R/testing/test_repeat_transactions_contracts.R
@@ -152,6 +152,15 @@ assert_error_matching(
   "unique",
   "Duplicate input ids must abort."
 )
+duplicate_rows <- rbind(fixture, fixture[1])
+duplicate_rows[.N, house_id := "04jkl"]
+duplicate_config <- make_config("duplicate-rows")
+duplicate_config$duplicate_check_cols <- setdiff(names(fixture), "house_id")
+assert_error_matching(
+  build_repeat_mapping(duplicate_rows, duplicate_config),
+  "exact duplicates",
+  "Full-field duplicate checks must abort even when transaction ids differ."
+)
 assert_error_matching(
   build_repeat_mapping(missing_fixture, make_config("coverage", coverage_floor = 0.9)),
   "coverage",

--- a/scripts/R/testing/test_repeat_transactions_contracts.R
+++ b/scripts/R/testing/test_repeat_transactions_contracts.R
@@ -1,0 +1,265 @@
+# ==============================================================================
+# Repeat Transaction Pipeline Contract Tests
+# ==============================================================================
+
+# Runnable standalone via plain Rscript; exits non-zero on the first failure.
+
+assert_true <- function(condition, message) {
+  if (!isTRUE(condition)) stop(message, call. = FALSE)
+}
+
+assert_identical <- function(actual, expected, message) {
+  if (!identical(actual, expected)) {
+    stop(
+      paste0(
+        message,
+        "\nExpected: ", paste(capture.output(str(expected)), collapse = " "),
+        "\nActual: ", paste(capture.output(str(actual)), collapse = " ")
+      ),
+      call. = FALSE
+    )
+  }
+}
+
+assert_error_matching <- function(expr, pattern, message) {
+  err <- tryCatch({ force(expr); NULL }, error = identity)
+  assert_true(
+    inherits(err, "error") && grepl(pattern, conditionMessage(err)),
+    paste0(
+      message,
+      if (inherits(err, "error")) {
+        paste0("\nGot error: ", conditionMessage(err))
+      } else {
+        "\nNo error was raised."
+      }
+    )
+  )
+}
+
+suppressPackageStartupMessages({
+  library(arrow)
+  library(data.table)
+  library(here)
+})
+
+source(here::here("scripts", "R", "utils", "hash_utils.R"))
+source(here::here("scripts", "R", "utils", "repeat_transactions_utils.R"))
+
+test_dir <- tempfile("repeat-contracts-")
+dir.create(test_dir, recursive = TRUE)
+on.exit(unlink(test_dir, recursive = TRUE), add = TRUE)
+
+fixture <- data.table(
+  house_id = c("01abc", "02def", "03ghi"),
+  postcode = c("SW1A 1AA", "SW1A 1AA", "E1 6AN"),
+  paon = c("10", "10", "7"),
+  saon = c(NA_character_, NA_character_, "FLAT 2"),
+  street = c("ST. JOHN'S ROAD", "ST JOHNS ROAD", "BRICK LANE"),
+  date_of_transfer = as.Date(c("2018-01-01", "2022-01-01", "2023-03-15")),
+  price = c(100000, 120000, 450000),
+  property_type = c("T", "T", "F")
+)
+
+make_config <- function(name = "base", coverage_floor = 0) {
+  list(
+    id_col = "house_id",
+    date_col = "date_of_transfer",
+    price_col = "price",
+    postcode_col = "postcode",
+    address_cols = c("postcode", "paon", "saon", "street"),
+    primary_address_col = "paon",
+    property_type_col = "property_type",
+    input_path = file.path(test_dir, paste0(name, "-input.parquet")),
+    output_path = file.path(test_dir, paste0(name, "-mapping.parquet")),
+    large_group_review_path = file.path(test_dir, paste0(name, "-large.parquet")),
+    price_ratio_review_path = file.path(test_dir, paste0(name, "-ratios.parquet")),
+    market = "sales",
+    log_name = paste0("repeat-contract-", name),
+    year_min = 2014L,
+    year_max = 2024L,
+    key_coverage_floor = coverage_floor,
+    repeat_share_floor = 0,
+    large_group_size = 12L,
+    extreme_annualized_price_ratio = 4
+  )
+}
+
+# Shared hash serialization is deterministic and type-stable.
+hash_input <- data.table(
+  postcode = c("AB12CD", "AB12CD"),
+  address_line_01 = c("1 HIGH STREET", "1 HIGH STREET"),
+  address_line_02 = c(NA_character_, NA_character_),
+  address_line_03 = c("", ""),
+  listing_price = c(1200, 1200),
+  latest_to_rent = as.Date(c("2022-01-03", "2022-01-03")),
+  rented = as.Date(c(NA, NA))
+)
+hashes <- hash_rental_identity(hash_input)
+assert_identical(hashes[[1]], hashes[[2]], "Equal rental composites must hash equally.")
+assert_true(all(grepl("^[0-9a-f]{16}$", hashes)), "Hashes must be lowercase 16-character hex.")
+assert_identical(
+  hash_transaction_id(c("{ABC}", "{ABC}")),
+  rep(hash_transaction_id("{ABC}"), 2L),
+  "Transaction-id hashing must be deterministic and vectorised."
+)
+reserved_input <- data.table(value = paste0("unsafe", HASH_FIELD_SEPARATOR))
+assert_error_matching(
+  serialize_hash_fields(reserved_input, "value"),
+  "reserved",
+  "Hash serialization must reject reserved tokens in source fields."
+)
+
+# Happy path, punctuation normalization, missing-component handling, and singles.
+base_result <- build_repeat_mapping(fixture, make_config())
+assert_identical(nrow(base_result$mapping), 3L, "All keyable transactions, including singles, must be mapped.")
+assert_identical(sort(unique(base_result$mapping$repeat_count)), c(1L, 2L), "Repeat counts must include groups of one and two.")
+assert_identical(uniqueN(base_result$mapping$repeat_id), 2L, "Equivalent punctuated addresses must share a repeat id.")
+assert_true(!grepl("NA", base_result$keyed_data$address_key[[1]], fixed = TRUE), "A missing address component must not inject literal NA into the key.")
+assert_identical(
+  base_result$keyed_data$repeat_id,
+  hash_serialized_values(base_result$keyed_data$address_key),
+  "Each repeat id must equal the hash of its normalized address key."
+)
+
+sorted_mapping <- function(x) setorder(copy(x), house_id)[]
+shuffled_result <- build_repeat_mapping(fixture[c(3, 1, 2)], make_config("shuffled"))
+second_result <- build_repeat_mapping(copy(fixture), make_config("second"))
+assert_identical(sorted_mapping(base_result$mapping), sorted_mapping(shuffled_result$mapping), "Row order must not affect mappings.")
+assert_identical(sorted_mapping(base_result$mapping), sorted_mapping(second_result$mapping), "Repeated runs must yield value-identical mappings.")
+
+missing_fixture <- rbind(
+  fixture,
+  data.table(
+    house_id = "04jkl", postcode = "N1 1AA", paon = NA_character_,
+    saon = NA_character_, street = "UPPER STREET",
+    date_of_transfer = as.Date("2023-06-01"), price = 500000,
+    property_type = "F"
+  )
+)
+missing_result <- build_repeat_mapping(missing_fixture, make_config("missing"))
+assert_identical(missing_result$metrics$excluded_count, 1L, "Exactly one missing-primary row must be excluded.")
+assert_true(!("04jkl" %in% missing_result$mapping$house_id), "Rows without a primary address must not enter the mapping.")
+
+singles <- copy(fixture)
+singles[, `:=`(postcode = c("A1", "B1", "C1"), paon = c("1", "2", "3"))]
+singles_result <- build_repeat_mapping(singles, make_config("singles"))
+assert_true(all(singles_result$mapping$repeat_count == 1L), "Zero-repeat input must retain every single with repeat_count one.")
+assert_true(all(grepl("^[0-9a-f]{16}$", singles_result$mapping$repeat_id)), "Singles must have hashed repeat ids without sentinels.")
+
+duplicate_ids <- rbind(fixture, fixture[1])
+assert_error_matching(
+  build_repeat_mapping(duplicate_ids, make_config("duplicate-ids")),
+  "unique",
+  "Duplicate input ids must abort."
+)
+assert_error_matching(
+  build_repeat_mapping(missing_fixture, make_config("coverage", coverage_floor = 0.9)),
+  "coverage",
+  "Coverage below the configured floor must abort."
+)
+
+large_fixture <- fixture[rep(1, 15)]
+large_fixture[, `:=`(
+  house_id = sprintf("large-%02d", seq_len(.N)),
+  date_of_transfer = as.Date("2010-01-01") + seq_len(.N) * 365,
+  price = 100000 + seq_len(.N) * 1000
+)]
+large_config <- make_config("large")
+large_config$year_min <- 2010L
+large_config$year_max <- 2030L
+large_result <- build_repeat_mapping(large_fixture, large_config)
+assert_identical(nrow(large_result$large_groups), 1L, "A 15-transaction group must be routed to review without failing.")
+
+mixed_fixture <- copy(fixture)
+mixed_fixture[2, property_type := "F"]
+warnings <- character()
+mixed_result <- withCallingHandlers(
+  build_repeat_mapping(mixed_fixture, make_config("mixed-types")),
+  warning = function(w) {
+    warnings <<- c(warnings, conditionMessage(w))
+    invokeRestart("muffleWarning")
+  }
+)
+assert_true(any(grepl("property type", warnings, ignore.case = TRUE)), "Mixed property types must warn rather than fail.")
+assert_identical(nrow(mixed_result$mapping), 3L, "Warn-only diagnostics must not remove mapped rows.")
+
+# Arrow integration: literal schema, review files, manifest round-trip, and first-generation log.
+logs <- character()
+integration_config <- make_config("integration")
+arrow::write_parquet(fixture, integration_config$input_path)
+run_result <- run_repeat_transactions(
+  integration_config,
+  log_fn = function(level, message) logs <<- c(logs, paste(level, message))
+)
+assert_true(any(grepl("first generation", logs, ignore.case = TRUE)), "The first run must log that manifest diffing was skipped.")
+assert_true(file.exists(integration_config$output_path), "The mapping parquet must be written.")
+assert_true(file.exists(integration_config$large_group_review_path), "The large-group review parquet must be written even when empty.")
+assert_true(file.exists(integration_config$price_ratio_review_path), "The price-ratio review parquet must be written even when empty.")
+
+written <- arrow::read_parquet(integration_config$output_path, as_data_frame = FALSE)
+assert_identical(names(written), c("house_id", "repeat_id", "repeat_count"), "The mapping must have exactly the declared three columns.")
+assert_identical(written$schema$field(0)$type$ToString(), "string", "The transaction id Arrow type must be utf8/string.")
+assert_identical(written$schema$field(1)$type$ToString(), "string", "repeat_id Arrow type must be utf8/string.")
+assert_identical(written$schema$field(2)$type$ToString(), "int32", "repeat_count Arrow type must be int32.")
+
+manifest <- written$metadata
+expected_manifest_keys <- c(
+  "repeat_manifest_version", "input_path", "input_row_count", "input_mtime",
+  "run_timestamp", "keyed_count", "excluded_count", "key_coverage",
+  "repeat_share", "largest_group_size", "market", "repeat_count_semantics"
+)
+assert_true(all(expected_manifest_keys %in% names(manifest)), "Every required manifest key must round-trip through Arrow metadata.")
+assert_identical(manifest$input_path, normalizePath(integration_config$input_path), "Manifest input_path must identify the production-read source.")
+assert_identical(manifest$input_row_count, "3", "Manifest input row count must round-trip as text.")
+assert_identical(manifest$keyed_count, "3", "Manifest keyed count must round-trip as text.")
+assert_identical(manifest$excluded_count, "0", "Manifest excluded count must round-trip as text.")
+
+rerun_logs <- character()
+run_repeat_transactions(
+  integration_config,
+  log_fn = function(level, message) rerun_logs <<- c(rerun_logs, paste(level, message))
+)
+assert_true(any(grepl("manifest delta", rerun_logs, ignore.case = TRUE)), "A compatible prior manifest must produce a logged delta.")
+
+# Both thin entry scripts must accept an in-memory fixture and isolated outputs.
+sales_env <- new.env(parent = globalenv())
+sys.source(
+  here::here("scripts", "R", "06_analysis_datasets", "repeat_sales.R"),
+  envir = sales_env
+)
+sales_entry_config <- sales_env$repeat_sales_config(test_dir)
+sales_entry_config$input_path <- file.path(test_dir, "sales-entry-input.parquet")
+sales_entry_config$log_file <- file.path(test_dir, "sales-entry.log")
+sales_env$main(sales_entry_config, data = fixture)
+assert_true(
+  file.exists(sales_entry_config$output_path),
+  "The repeat-sales entry script must run a fixture end-to-end."
+)
+
+rentals_fixture <- data.table(
+  rental_id = c("rental-01", "rental-02", "rental-03"),
+  postcode = c("SW1A 1AA", "SW1A 1AA", "E1 6AN"),
+  address_line_01 = c("10 High Street", "10 HIGH STREET", "7 Brick Lane"),
+  address_line_02 = c(NA_character_, NA_character_, "Flat 2"),
+  address_line_03 = NA_character_,
+  listing_price = c(1200, 1300, 1800),
+  latest_to_rent = as.Date(c("2019-01-01", "2022-01-01", "2023-01-01")),
+  rented = as.Date(c("2019-01-15", "2022-01-15", "2023-01-15")),
+  rented_est = as.Date(c("2019-01-15", "2022-01-15", "2023-01-15")),
+  property_type = c("T", "T", "F")
+)
+rentals_env <- new.env(parent = globalenv())
+sys.source(
+  here::here("scripts", "R", "06_analysis_datasets", "repeat_rentals.R"),
+  envir = rentals_env
+)
+rentals_entry_config <- rentals_env$repeat_rentals_config(test_dir)
+rentals_entry_config$input_path <- file.path(test_dir, "rentals-entry-input.parquet")
+rentals_entry_config$log_file <- file.path(test_dir, "rentals-entry.log")
+rentals_env$main(rentals_entry_config, data = rentals_fixture)
+assert_true(
+  file.exists(rentals_entry_config$output_path),
+  "The repeat-rentals entry script must run a fixture end-to-end."
+)
+
+cat("Repeat transaction contract tests passed.\n")

--- a/scripts/R/testing/test_repeat_transactions_contracts.R
+++ b/scripts/R/testing/test_repeat_transactions_contracts.R
@@ -97,6 +97,26 @@ hash_input <- data.table(
 hashes <- hash_rental_identity(hash_input)
 assert_identical(hashes[[1]], hashes[[2]], "Equal rental composites must hash equally.")
 assert_true(all(grepl("^[0-9a-f]{16}$", hashes)), "Hashes must be lowercase 16-character hex.")
+expected_rental_serialization <- paste(
+  "AB12CD", "1 HIGH STREET", HASH_NA_TOKEN, "", "1200", "2022-01-03",
+  HASH_NA_TOKEN,
+  sep = HASH_FIELD_SEPARATOR
+)
+assert_identical(
+  serialize_hash_fields(hash_input[1], names(hash_input)),
+  expected_rental_serialization,
+  "Rental identity serialization is a locked public-ID preimage contract."
+)
+assert_identical(
+  hashes[[1]],
+  "61ec4f1ca85dfdb2",
+  "The locked rental identity fixture must retain its xxhash64 value."
+)
+assert_identical(
+  hash_transaction_id("{ABC}"),
+  "094a16add8cb5eb0",
+  "The locked Land Registry transaction fixture must retain its xxhash64 value."
+)
 assert_identical(
   hash_transaction_id(c("{ABC}", "{ABC}")),
   rep(hash_transaction_id("{ABC}"), 2L),
@@ -119,6 +139,16 @@ assert_identical(
   base_result$keyed_data$repeat_id,
   hash_serialized_values(base_result$keyed_data$address_key),
   "Each repeat id must equal the hash of its normalized address key."
+)
+assert_identical(
+  base_result$keyed_data$address_key[[1]],
+  "SW1A 1AA|10||ST JOHNS ROAD",
+  "The normalized repeat-address preimage is a locked contract."
+)
+assert_identical(
+  base_result$keyed_data$repeat_id[[1]],
+  "89f5f526a23b82ad",
+  "The locked repeat-address fixture must retain its xxhash64 value."
 )
 
 sorted_mapping <- function(x) setorder(copy(x), house_id)[]
@@ -165,6 +195,23 @@ assert_error_matching(
   build_repeat_mapping(missing_fixture, make_config("coverage", coverage_floor = 0.9)),
   "coverage",
   "Coverage below the configured floor must abort."
+)
+
+original_hash_serialized_values <- hash_serialized_values
+assign(
+  "hash_serialized_values",
+  function(x) rep("0000000000000000", length(x)),
+  envir = .GlobalEnv
+)
+assert_error_matching(
+  build_repeat_mapping(fixture, make_config("collision")),
+  "one-to-one",
+  "Distinct address keys that collide must abort."
+)
+assign(
+  "hash_serialized_values",
+  original_hash_serialized_values,
+  envir = .GlobalEnv
 )
 
 large_fixture <- fixture[rep(1, 15)]
@@ -230,6 +277,14 @@ run_repeat_transactions(
 )
 assert_true(any(grepl("manifest delta", rerun_logs, ignore.case = TRUE)), "A compatible prior manifest must produce a logged delta.")
 
+corrupt_manifest_path <- file.path(test_dir, "corrupt-previous.parquet")
+writeBin(charToRaw("not parquet"), corrupt_manifest_path)
+assert_error_matching(
+  read_repeat_manifest(corrupt_manifest_path),
+  "unreadable",
+  "An existing unreadable repeat mapping must fail closed."
+)
+
 # Both thin entry scripts must accept an in-memory fixture and isolated outputs.
 sales_env <- new.env(parent = globalenv())
 sys.source(
@@ -239,6 +294,11 @@ sys.source(
 sales_entry_config <- sales_env$repeat_sales_config(test_dir)
 sales_entry_config$input_path <- file.path(test_dir, "sales-entry-input.parquet")
 sales_entry_config$log_file <- file.path(test_dir, "sales-entry.log")
+assert_identical(
+  c(sales_entry_config$key_coverage_floor, sales_entry_config$repeat_share_floor),
+  c(0.99, 0.35),
+  "Sales production floors must remain locked below the accepted baseline."
+)
 sales_env$main(sales_entry_config, data = fixture)
 assert_true(
   file.exists(sales_entry_config$output_path),
@@ -265,6 +325,11 @@ sys.source(
 rentals_entry_config <- rentals_env$repeat_rentals_config(test_dir)
 rentals_entry_config$input_path <- file.path(test_dir, "rentals-entry-input.parquet")
 rentals_entry_config$log_file <- file.path(test_dir, "rentals-entry.log")
+assert_identical(
+  c(rentals_entry_config$key_coverage_floor, rentals_entry_config$repeat_share_floor),
+  c(0.99, 0.70),
+  "Rental production floors must remain locked below the accepted baseline."
+)
 rentals_env$main(rentals_entry_config, data = rentals_fixture)
 assert_true(
   file.exists(rentals_entry_config$output_path),

--- a/scripts/R/testing/test_verify_id_artifact_match_rates_contracts.R
+++ b/scripts/R/testing/test_verify_id_artifact_match_rates_contracts.R
@@ -1,0 +1,59 @@
+# ==============================================================================
+# ID Artifact Verifier Specification Contracts
+# ==============================================================================
+
+if (!requireNamespace("here", quietly = TRUE)) {
+  stop("Package `here` is required to run this test.", call. = FALSE)
+}
+
+assert_identical <- function(actual, expected, message) {
+  if (!identical(actual, expected)) {
+    stop(message, call. = FALSE)
+  }
+}
+
+verifier_env <- new.env(parent = globalenv())
+sys.source(
+  here::here("scripts", "R", "testing", "verify_id_artifact_match_rates.R"),
+  envir = verifier_env
+)
+
+specs <- verifier_env$default_id_artifact_specs()
+spec_by_name <- stats::setNames(specs, vapply(specs, `[[`, character(1), "name"))
+
+assert_identical(
+  normalizePath(spec_by_name$repeated_sales$source_path, mustWork = FALSE),
+  normalizePath(
+    here::here("data", "processed", "house_price_long_run.parquet"),
+    mustWork = FALSE
+  ),
+  "Repeated-sales verification must use the long-run sales source."
+)
+assert_identical(
+  normalizePath(spec_by_name$repeated_rentals$source_path, mustWork = FALSE),
+  normalizePath(
+    here::here(
+      "data", "processed", "zoopla", "zoopla_rentals_long_run.parquet"
+    ),
+    mustWork = FALSE
+  ),
+  "Repeated-rentals verification must use the long-run rental source."
+)
+assert_identical(
+  normalizePath(spec_by_name$study_period_sales$source_path, mustWork = FALSE),
+  normalizePath(
+    here::here("data", "processed", "house_price.parquet"),
+    mustWork = FALSE
+  ),
+  "Study-period sales verification must continue to use the study source."
+)
+assert_identical(
+  normalizePath(spec_by_name$study_period_rentals$source_path, mustWork = FALSE),
+  normalizePath(
+    here::here("data", "processed", "zoopla", "zoopla_rentals.parquet"),
+    mustWork = FALSE
+  ),
+  "Study-period rental verification must continue to use the study source."
+)
+
+message("ID artifact verifier specification contract tests passed.")

--- a/scripts/R/testing/test_verify_id_artifact_match_rates_contracts.R
+++ b/scripts/R/testing/test_verify_id_artifact_match_rates_contracts.R
@@ -22,6 +22,20 @@ specs <- verifier_env$default_id_artifact_specs()
 spec_by_name <- stats::setNames(specs, vapply(specs, `[[`, character(1), "name"))
 
 assert_identical(
+  sort(names(spec_by_name)),
+  sort(c(
+    "spill_house_lookup", "spill_rental_lookup",
+    "repeated_sales", "repeated_rentals",
+    "study_period_sales", "study_period_rentals",
+    "prior_to_sale", "prior_to_rental",
+    "prior_to_sale_house_site", "prior_to_rental_rental_site",
+    "within_radius_sales", "within_radius_rentals",
+    "general_panel_sales", "general_panel_rentals"
+  )),
+  "The verifier inventory must contain the exact 14 declared ID-keyed artifacts."
+)
+
+assert_identical(
   normalizePath(spec_by_name$repeated_sales$source_path, mustWork = FALSE),
   normalizePath(
     here::here("data", "processed", "house_price_long_run.parquet"),

--- a/scripts/R/testing/verify_id_artifact_match_rates.R
+++ b/scripts/R/testing/verify_id_artifact_match_rates.R
@@ -225,7 +225,9 @@ main <- function() {
     "artifact", "id_column", "id_type", "total_rows", "nonmissing_ids",
     "missing_ids", "matched_ids", "unmatched_ids", "match_rate"
   )])
-  message("All declared ID-keyed artifacts match their cleaned inputs at 100%.")
+  message(
+    "All nonmissing IDs in declared ID-keyed artifacts match their cleaned inputs at 100%."
+  )
   invisible(report)
 }
 

--- a/scripts/R/testing/verify_id_artifact_match_rates.R
+++ b/scripts/R/testing/verify_id_artifact_match_rates.R
@@ -1,0 +1,232 @@
+# ==============================================================================
+# Transaction-ID Artifact Match-Rate Verification
+# ==============================================================================
+#
+# Purpose: Certify referential integrity after the positional-to-hash ID rebuild.
+#          Every nonmissing transaction ID in each declared regenerated artifact
+#          must match its declared cleaned source. Artifacts are scanned in
+#          bounded Arrow record batches; canonical data is read only.
+#
+# Output:
+#   - output/log/id_artifact_match_rates.csv
+#
+# This is a one-time transition tripwire, not a substitute for producer-specific
+# completeness and correctness contract tests.
+#
+# ==============================================================================
+
+if (!requireNamespace("here", quietly = TRUE)) {
+  stop("Package `here` is required to run this script.", call. = FALSE)
+}
+if (!requireNamespace("arrow", quietly = TRUE) ||
+    !requireNamespace("dplyr", quietly = TRUE) ||
+    !requireNamespace("tibble", quietly = TRUE)) {
+  stop("Packages `arrow`, `dplyr`, and `tibble` are required.", call. = FALSE)
+}
+
+id_field_type <- function(schema, id) {
+  positions <- match(id, schema$names)
+  if (is.na(positions)) {
+    stop("Dataset is missing transaction ID column `", id, "`.", call. = FALSE)
+  }
+  schema$fields[[positions]]$type$ToString()
+}
+
+read_unique_source_ids <- function(source_path, id) {
+  if (!file.exists(source_path) && !dir.exists(source_path)) {
+    stop("Cleaned source does not exist: ", source_path, call. = FALSE)
+  }
+  dataset <- arrow::open_dataset(source_path)
+  source_type <- id_field_type(dataset$schema, id)
+  if (!identical(source_type, "string")) {
+    stop(
+      "Cleaned source `", id, "` must be Arrow utf8/string; found ",
+      source_type, ".",
+      call. = FALSE
+    )
+  }
+  ids <- dataset |>
+    dplyr::select(dplyr::all_of(id)) |>
+    dplyr::collect() |>
+    dplyr::pull(dplyr::all_of(id))
+  if (anyNA(ids) || any(!nzchar(ids))) {
+    stop("Cleaned source `", id, "` contains missing or empty IDs.", call. = FALSE)
+  }
+  if (anyDuplicated(ids)) {
+    stop("Cleaned source `", id, "` contains duplicate IDs.", call. = FALSE)
+  }
+  ids
+}
+
+verify_id_artifact <- function(name, artifact_path, id, source_ids) {
+  if (!file.exists(artifact_path) && !dir.exists(artifact_path)) {
+    stop("Regenerated artifact does not exist: ", artifact_path, call. = FALSE)
+  }
+  if (!is.character(source_ids) || anyNA(source_ids) || anyDuplicated(source_ids)) {
+    stop("`source_ids` must be unique, nonmissing character IDs.", call. = FALSE)
+  }
+
+  dataset <- arrow::open_dataset(artifact_path)
+  id_type <- id_field_type(dataset$schema, id)
+  if (!identical(id_type, "string")) {
+    stop(
+      "Artifact `", name, "` must expose `", id,
+      "` as Arrow utf8/string; found ", id_type, ".",
+      call. = FALSE
+    )
+  }
+
+  reader <- dataset |>
+    dplyr::select(dplyr::all_of(id)) |>
+    arrow::as_record_batch_reader()
+  total_rows <- 0
+  nonmissing_ids <- 0
+  matched_ids <- 0
+  missing_ids <- 0
+  unmatched_examples <- character()
+
+  repeat {
+    batch <- reader$read_next_batch()
+    if (is.null(batch)) break
+    values <- as.data.frame(batch)[[id]]
+    total_rows <- total_rows + length(values)
+    present <- !is.na(values) & nzchar(values)
+    missing_ids <- missing_ids + sum(!present)
+    if (any(present)) {
+      present_values <- values[present]
+      matched <- present_values %in% source_ids
+      nonmissing_ids <- nonmissing_ids + length(present_values)
+      matched_ids <- matched_ids + sum(matched)
+      if (any(!matched) && length(unmatched_examples) < 10L) {
+        unmatched_examples <- unique(c(
+          unmatched_examples,
+          present_values[!matched]
+        ))
+        unmatched_examples <- head(unmatched_examples, 10L)
+      }
+    }
+  }
+  reader$Close()
+
+  match_rate <- if (nonmissing_ids == 0) NA_real_ else matched_ids / nonmissing_ids
+  tibble::tibble(
+    artifact = name,
+    artifact_path = normalizePath(artifact_path, mustWork = TRUE),
+    id_column = id,
+    id_type = id_type,
+    total_rows = as.double(total_rows),
+    nonmissing_ids = as.double(nonmissing_ids),
+    missing_ids = as.double(missing_ids),
+    matched_ids = as.double(matched_ids),
+    unmatched_ids = as.double(nonmissing_ids - matched_ids),
+    match_rate = match_rate,
+    unmatched_examples = paste(unmatched_examples, collapse = ";")
+  )
+}
+
+verify_id_artifacts <- function(
+    specs,
+    required_match_rate = 1,
+    report_path = NULL) {
+  if (!is.numeric(required_match_rate) || length(required_match_rate) != 1L ||
+      is.na(required_match_rate) || required_match_rate < 0 ||
+      required_match_rate > 1) {
+    stop("`required_match_rate` must lie in [0, 1].", call. = FALSE)
+  }
+  if (!is.list(specs) || length(specs) == 0L) {
+    stop("`specs` must be a non-empty artifact specification list.", call. = FALSE)
+  }
+
+  source_cache <- new.env(parent = emptyenv())
+  results <- lapply(specs, function(spec) {
+    required <- c("name", "artifact_path", "source_path", "id")
+    if (!all(required %in% names(spec))) {
+      stop("Each artifact spec must name: ", paste(required, collapse = ", "), ".", call. = FALSE)
+    }
+    cache_key <- paste(normalizePath(spec$source_path, mustWork = FALSE), spec$id)
+    if (!exists(cache_key, envir = source_cache, inherits = FALSE)) {
+      assign(
+        cache_key,
+        read_unique_source_ids(spec$source_path, spec$id),
+        envir = source_cache
+      )
+    }
+    verify_id_artifact(
+      spec$name,
+      spec$artifact_path,
+      spec$id,
+      get(cache_key, envir = source_cache, inherits = FALSE)
+    )
+  })
+  report <- dplyr::bind_rows(results)
+
+  if (!is.null(report_path)) {
+    dir.create(dirname(report_path), recursive = TRUE, showWarnings = FALSE)
+    utils::write.csv(report, report_path, row.names = FALSE, na = "")
+  }
+
+  failed <- is.na(report$match_rate) |
+    report$match_rate < required_match_rate |
+    report$unmatched_ids > 0
+  if (any(failed)) {
+    labels <- paste0(
+      report$artifact[failed], "=",
+      sprintf("%.6f%%", 100 * report$match_rate[failed])
+    )
+    stop(
+      "ID artifact match rate below required ",
+      sprintf("%.0f%%", 100 * required_match_rate),
+      ": ", paste(labels, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  report
+}
+
+default_id_artifact_specs <- function() {
+  processed <- here::here("data", "processed")
+  sale_source <- file.path(processed, "house_price.parquet")
+  rental_source <- file.path(processed, "zoopla", "zoopla_rentals.parquet")
+  sale_long_run_source <- file.path(processed, "house_price_long_run.parquet")
+  rental_long_run_source <- file.path(
+    processed, "zoopla", "zoopla_rentals_long_run.parquet"
+  )
+  spec <- function(name, path, source, id) {
+    list(name = name, artifact_path = path, source_path = source, id = id)
+  }
+
+  list(
+    spec("spill_house_lookup", file.path(processed, "spill_house_lookup.parquet"), sale_source, "house_id"),
+    spec("spill_rental_lookup", file.path(processed, "zoopla", "spill_rental_lookup.parquet"), rental_source, "rental_id"),
+    spec("repeated_sales", file.path(processed, "repeated_transactions", "repeated_sales.parquet"), sale_long_run_source, "house_id"),
+    spec("repeated_rentals", file.path(processed, "repeated_transactions", "repeated_rentals.parquet"), rental_long_run_source, "rental_id"),
+    spec("study_period_sales", file.path(processed, "cross_section", "sales", "study_period"), sale_source, "house_id"),
+    spec("study_period_rentals", file.path(processed, "cross_section", "rentals", "study_period"), rental_source, "rental_id"),
+    spec("prior_to_sale", file.path(processed, "cross_section", "sales", "prior_to_sale"), sale_source, "house_id"),
+    spec("prior_to_rental", file.path(processed, "cross_section", "rentals", "prior_to_rental"), rental_source, "rental_id"),
+    spec("prior_to_sale_house_site", file.path(processed, "cross_section", "sales", "prior_to_sale_house_site"), sale_source, "house_id"),
+    spec("prior_to_rental_rental_site", file.path(processed, "cross_section", "rentals", "prior_to_rental_rental_site"), rental_source, "rental_id"),
+    spec("within_radius_sales", file.path(processed, "within_radius_panel", "sales"), sale_source, "house_id"),
+    spec("within_radius_rentals", file.path(processed, "within_radius_panel", "rentals"), rental_source, "rental_id"),
+    spec("general_panel_sales", file.path(processed, "general_panel", "sales"), sale_source, "house_id"),
+    spec("general_panel_rentals", file.path(processed, "general_panel", "rentals"), rental_source, "rental_id")
+  )
+}
+
+main <- function() {
+  report_path <- here::here("output", "log", "id_artifact_match_rates.csv")
+  report <- verify_id_artifacts(
+    default_id_artifact_specs(),
+    required_match_rate = 1,
+    report_path = report_path
+  )
+  print(report[, c(
+    "artifact", "id_column", "id_type", "total_rows", "nonmissing_ids",
+    "missing_ids", "matched_ids", "unmatched_ids", "match_rate"
+  )])
+  message("All declared ID-keyed artifacts match their cleaned inputs at 100%.")
+  invisible(report)
+}
+
+if (sys.nframe() == 0L) main()

--- a/scripts/R/utils/cross_section_study_period_utils.R
+++ b/scripts/R/utils/cross_section_study_period_utils.R
@@ -44,7 +44,7 @@ study_period_public_schema <- function(market) {
 
   if (market == "sale") {
     return(arrow::schema(
-      house_id = arrow::int32(),
+      house_id = arrow::utf8(),
       price = arrow::int32(),
       ppd_category = arrow::utf8(),
       n_days_in_window = arrow::int32(),
@@ -64,7 +64,7 @@ study_period_public_schema <- function(market) {
   }
 
   arrow::schema(
-    rental_id = arrow::int32(),
+    rental_id = arrow::utf8(),
     listing_price = arrow::float64(),
     n_days_in_window = arrow::int32(),
     spill_hrs = arrow::float64(),
@@ -252,12 +252,14 @@ study_period_source_ledger <- function(source, contract) {
   source_columns <- contract$source_columns
   source <- source[, ..source_columns]
   id <- source[[contract$id]]
-  if (!is.numeric(id) || anyNA(id) || any(!is.finite(id)) ||
-      any(id != floor(id)) || any(id < -.Machine$integer.max - 1) ||
-      any(id > .Machine$integer.max)) {
-    stop(contract$id, " must contain nonmissing lossless int32 values.", call. = FALSE)
+  valid_type <- is.character(id) || is.numeric(id)
+  invalid_numeric <- is.numeric(id) && any(
+    !is.na(id) & (!is.finite(id) | id != floor(id))
+  )
+  invalid_character <- is.character(id) && any(!is.na(id) & !nzchar(id))
+  if (!valid_type || anyNA(id) || invalid_numeric || invalid_character) {
+    stop(contract$id, " must contain nonmissing transaction identifiers.", call. = FALSE)
   }
-  data.table::set(source, j = contract$id, value = as.integer(id))
   if (anyDuplicated(source[[contract$id]])) {
     stop("Source metadata contains duplicate transaction identifiers.", call. = FALSE)
   }
@@ -310,12 +312,18 @@ study_period_validate_lookup_row_group <- function(row_group, contract, ledger) 
   }
 
   transaction_id <- lookup[[contract$id]]
-  if (!is.numeric(transaction_id) || anyNA(transaction_id) ||
-      any(!is.finite(transaction_id)) ||
-      any(transaction_id != floor(transaction_id))) {
-    stop("Lookup transaction identifiers must be nonmissing integers.", call. = FALSE)
+  valid_type <- is.character(transaction_id) || is.numeric(transaction_id)
+  invalid_numeric <- is.numeric(transaction_id) && any(
+    !is.na(transaction_id) &
+      (!is.finite(transaction_id) | transaction_id != floor(transaction_id))
+  )
+  invalid_character <- is.character(transaction_id) && any(
+    !is.na(transaction_id) & !nzchar(transaction_id)
+  )
+  if (!valid_type || anyNA(transaction_id) ||
+      invalid_numeric || invalid_character) {
+    stop("Lookup transaction identifiers must be nonmissing.", call. = FALSE)
   }
-  data.table::set(lookup, j = contract$id, value = as.integer(transaction_id))
   source_position <- match(lookup[[contract$id]], ledger[[contract$id]])
   if (anyNA(source_position)) {
     stop("Lookup contains a transaction ID absent from the source ledger.", call. = FALSE)
@@ -422,9 +430,10 @@ study_period_validate_and_cast_public <- function(
         stop(column, " must contain nonmissing logical values.", call. = FALSE)
       }
     } else if (target == "string") {
-      if (!is.character(value) || anyNA(value)) {
+      if ((!is.character(value) && !is.numeric(value)) || anyNA(value)) {
         stop(column, " must contain nonmissing strings.", call. = FALSE)
       }
+      data[[column]] <- as.character(value)
     }
   }
 
@@ -537,35 +546,43 @@ study_period_reduce_validated_lookup_row_group <- function(
     expanded <- matched[rep(seq_len(matched_rows), each = length(radii))]
     expanded[, radius := rep(radii, times = matched_rows)]
     expanded <- expanded[distance_m <= radius]
-    totals <- data.table::as.data.table(data.table::copy(site_totals))
-    required_totals <- c(
-      "site_id", "spill_count", "spill_hrs", "has_missing_evidence"
-    )
-    if (!all(required_totals %in% names(totals)) || anyDuplicated(totals$site_id)) {
-      stop("Collapsed Site Group totals violate their unique schema.", call. = FALSE)
-    }
-    expanded <- totals[expanded, on = "site_id"]
-    expanded[, evidence_unknown :=
-      is.na(has_missing_evidence) | has_missing_evidence |
-        is.na(spill_count) | is.na(spill_hrs)]
-    aggregate <- expanded[, {
-      if (.N < 1L || anyNA(distance_m)) {
-        stop(
-          "Matched Site Group aggregation requires nonmissing distances.",
-          call. = FALSE
-        )
-      }
-      unknown <- any(evidence_unknown)
-      list(
-        n_spill_sites = as.integer(.N),
-        spill_count = if (unknown) NA_real_ else base::sum(spill_count),
-        spill_hrs = if (unknown) NA_real_ else base::sum(spill_hrs),
-        mean_distance = base::mean(distance_m),
-        min_distance = base::min(distance_m),
-        has_missing_site = unknown
+    if (nrow(expanded) > 0L) {
+      totals <- data.table::as.data.table(data.table::copy(site_totals))
+      required_totals <- c(
+        "site_id", "spill_count", "spill_hrs", "has_missing_evidence"
       )
-    }, by = c(id, "radius")]
-    base <- merge(base, aggregate, by = c(id, "radius"), all.x = TRUE, sort = FALSE)
+      if (!all(required_totals %in% names(totals)) || anyDuplicated(totals$site_id)) {
+        stop("Collapsed Site Group totals violate their unique schema.", call. = FALSE)
+      }
+      expanded <- totals[expanded, on = "site_id"]
+      expanded[, evidence_unknown :=
+        is.na(has_missing_evidence) | has_missing_evidence |
+          is.na(spill_count) | is.na(spill_hrs)]
+      aggregate <- expanded[, {
+        if (anyNA(distance_m)) {
+          stop(
+            "Matched Site Group aggregation requires nonmissing distances.",
+            call. = FALSE
+          )
+        }
+        unknown <- any(evidence_unknown)
+        list(
+          n_spill_sites = as.integer(.N),
+          spill_count = if (unknown) NA_real_ else base::sum(spill_count),
+          spill_hrs = if (unknown) NA_real_ else base::sum(spill_hrs),
+          mean_distance = base::mean(distance_m),
+          min_distance = base::min(distance_m),
+          has_missing_site = unknown
+        )
+      }, by = c(id, "radius")]
+      base <- merge(base, aggregate, by = c(id, "radius"), all.x = TRUE, sort = FALSE)
+    } else {
+      base[, `:=`(
+        n_spill_sites = NA_integer_, spill_count = NA_real_, spill_hrs = NA_real_,
+        mean_distance = NA_real_, min_distance = NA_real_,
+        has_missing_site = NA
+      )]
+    }
   } else {
     base[, `:=`(
       n_spill_sites = NA_integer_, spill_count = NA_real_, spill_hrs = NA_real_,

--- a/scripts/R/utils/cross_section_study_period_utils.R
+++ b/scripts/R/utils/cross_section_study_period_utils.R
@@ -252,13 +252,12 @@ study_period_source_ledger <- function(source, contract) {
   source_columns <- contract$source_columns
   source <- source[, ..source_columns]
   id <- source[[contract$id]]
-  valid_type <- is.character(id) || is.numeric(id)
-  invalid_numeric <- is.numeric(id) && any(
-    !is.na(id) & (!is.finite(id) | id != floor(id))
-  )
-  invalid_character <- is.character(id) && any(!is.na(id) & !nzchar(id))
-  if (!valid_type || anyNA(id) || invalid_numeric || invalid_character) {
-    stop(contract$id, " must contain nonmissing transaction identifiers.", call. = FALSE)
+  if (!is.character(id) || anyNA(id) || any(!nzchar(id))) {
+    stop(
+      contract$id,
+      " must contain nonmissing, nonempty character transaction identifiers.",
+      call. = FALSE
+    )
   }
   if (anyDuplicated(source[[contract$id]])) {
     stop("Source metadata contains duplicate transaction identifiers.", call. = FALSE)
@@ -312,17 +311,12 @@ study_period_validate_lookup_row_group <- function(row_group, contract, ledger) 
   }
 
   transaction_id <- lookup[[contract$id]]
-  valid_type <- is.character(transaction_id) || is.numeric(transaction_id)
-  invalid_numeric <- is.numeric(transaction_id) && any(
-    !is.na(transaction_id) &
-      (!is.finite(transaction_id) | transaction_id != floor(transaction_id))
-  )
-  invalid_character <- is.character(transaction_id) && any(
-    !is.na(transaction_id) & !nzchar(transaction_id)
-  )
-  if (!valid_type || anyNA(transaction_id) ||
-      invalid_numeric || invalid_character) {
-    stop("Lookup transaction identifiers must be nonmissing.", call. = FALSE)
+  if (!is.character(transaction_id) || anyNA(transaction_id) ||
+      any(!nzchar(transaction_id))) {
+    stop(
+      "Lookup transaction identifiers must be nonmissing, nonempty strings.",
+      call. = FALSE
+    )
   }
   source_position <- match(lookup[[contract$id]], ledger[[contract$id]])
   if (anyNA(source_position)) {
@@ -430,10 +424,9 @@ study_period_validate_and_cast_public <- function(
         stop(column, " must contain nonmissing logical values.", call. = FALSE)
       }
     } else if (target == "string") {
-      if ((!is.character(value) && !is.numeric(value)) || anyNA(value)) {
+      if (!is.character(value) || anyNA(value) || any(!nzchar(value))) {
         stop(column, " must contain nonmissing strings.", call. = FALSE)
       }
-      data[[column]] <- as.character(value)
     }
   }
 

--- a/scripts/R/utils/duckdb_refresh_utils.R
+++ b/scripts/R/utils/duckdb_refresh_utils.R
@@ -1,0 +1,90 @@
+# ==============================================================================
+# DuckDB Input Refresh Utilities
+# ==============================================================================
+
+#' Configure a stable, existing DuckDB spill directory beside the database
+#'
+#' @param con A DBI connection to DuckDB.
+#' @param db_path Path to the persistent DuckDB database.
+#' @return The normalized spill-directory path, invisibly.
+configure_duckdb_temp_directory <- function(con, db_path) {
+  spill_dir <- file.path(dirname(normalizePath(db_path, mustWork = FALSE)), "duckdb_temp")
+  dir.create(spill_dir, recursive = TRUE, showWarnings = FALSE)
+  spill_dir <- normalizePath(spill_dir, mustWork = TRUE)
+
+  DBI::dbExecute(
+    con,
+    paste(
+      "SET temp_directory =",
+      DBI::dbQuoteString(con, spill_dir)
+    )
+  )
+
+  invisible(spill_dir)
+}
+
+#' Replace one named DuckDB relation with a parquet-backed view
+#'
+#' Only the named relation is replaced. Other persistent database relations are
+#' left untouched, and the replacement is transactional so a failed view
+#' creation restores the prior relation.
+#'
+#' @param con A DBI connection to DuckDB.
+#' @param relation_name Name of the relation to replace.
+#' @param parquet_path Path to the current parquet file.
+#' @return NULL, invisibly.
+refresh_duckdb_parquet_view <- function(con, relation_name, parquet_path) {
+  if (!is.character(relation_name) || length(relation_name) != 1L ||
+      is.na(relation_name) || !nzchar(relation_name)) {
+    stop("`relation_name` must be one nonempty string.", call. = FALSE)
+  }
+  if ((!file.exists(parquet_path) && !dir.exists(parquet_path))) {
+    stop("Parquet input does not exist: ", parquet_path, call. = FALSE)
+  }
+
+  relation <- DBI::dbGetQuery(
+    con,
+    paste(
+      "SELECT table_type FROM information_schema.tables",
+      "WHERE table_schema = 'main' AND table_name = ?"
+    ),
+    params = list(relation_name)
+  )
+  if (nrow(relation) > 1L) {
+    stop("DuckDB relation name is ambiguous: ", relation_name, call. = FALSE)
+  }
+
+  quoted_name <- DBI::dbQuoteIdentifier(con, relation_name)
+  quoted_path <- DBI::dbQuoteString(
+    con,
+    normalizePath(parquet_path, mustWork = TRUE)
+  )
+
+  DBI::dbWithTransaction(con, {
+    if (nrow(relation) == 1L) {
+      drop_kind <- switch(
+        relation$table_type[[1L]],
+        "BASE TABLE" = "TABLE",
+        "VIEW" = "VIEW",
+        stop(
+          "Unsupported DuckDB relation type for `", relation_name, "`: ",
+          relation$table_type[[1L]],
+          call. = FALSE
+        )
+      )
+      DBI::dbExecute(
+        con,
+        paste("DROP", drop_kind, quoted_name)
+      )
+    }
+    DBI::dbExecute(
+      con,
+      paste0(
+        "CREATE VIEW ", quoted_name,
+        " AS SELECT * FROM read_parquet(", quoted_path, ")"
+      )
+    )
+  })
+
+  invisible(NULL)
+}

--- a/scripts/R/utils/hash_utils.R
+++ b/scripts/R/utils/hash_utils.R
@@ -1,0 +1,102 @@
+# ==============================================================================
+# Content-Stable Hash Utilities
+# ==============================================================================
+
+# ASCII record/unit separators are reserved so field boundaries and missing
+# values cannot be confused with source text. Callers fail before hashing if
+# either character appears in a non-missing source field.
+HASH_NA_TOKEN <- "\u001e"
+HASH_FIELD_SEPARATOR <- "\u001f"
+
+assert_hash_dependencies <- function() {
+  if (!requireNamespace("digest", quietly = TRUE)) {
+    stop(
+      "Package `digest` is required. Install project dependencies with `rv sync`.",
+      call. = FALSE
+    )
+  }
+}
+
+format_hash_field <- function(x) {
+  missing <- is.na(x)
+
+  if (inherits(x, "Date") || inherits(x, "POSIXt")) {
+    value <- format(x, "%Y-%m-%d")
+  } else if (is.numeric(x)) {
+    value <- format(x, scientific = FALSE, trim = TRUE)
+  } else {
+    value <- as.character(x)
+  }
+
+  value <- enc2utf8(value)
+  nonmissing <- value[!missing]
+  has_reserved <- vapply(
+    c(HASH_NA_TOKEN, HASH_FIELD_SEPARATOR),
+    function(token) any(grepl(token, nonmissing, fixed = TRUE)),
+    logical(1)
+  )
+  if (any(has_reserved)) {
+    stop("Hash input contains a reserved serialization token.", call. = FALSE)
+  }
+
+  value[missing] <- HASH_NA_TOKEN
+  value
+}
+
+#' Serialize ordered fields for stable hashing
+#'
+#' Field order is supplied explicitly. Dates use YYYY-MM-DD, numerics avoid
+#' scientific notation, strings are UTF-8, and missing values use a reserved
+#' token distinct from an empty string.
+serialize_hash_fields <- function(data, fields) {
+  if (!is.data.frame(data)) {
+    stop("`data` must be a data frame.", call. = FALSE)
+  }
+  if (!is.character(fields) || length(fields) == 0L || anyDuplicated(fields)) {
+    stop("`fields` must be a non-empty unique character vector.", call. = FALSE)
+  }
+
+  missing_fields <- setdiff(fields, names(data))
+  if (length(missing_fields) > 0L) {
+    stop(
+      "Missing hash fields: ", paste(missing_fields, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  serialized <- lapply(as.data.frame(data)[fields], format_hash_field)
+  do.call(paste, c(serialized, sep = HASH_FIELD_SEPARATOR))
+}
+
+#' Hash already-serialized UTF-8 values with xxhash64
+hash_serialized_values <- function(x) {
+  assert_hash_dependencies()
+  if (!is.character(x) || anyNA(x)) {
+    stop("Serialized hash input must be a non-missing character vector.", call. = FALSE)
+  }
+  digest::getVDigest("xxhash64")(enc2utf8(x), serialize = FALSE)
+}
+
+#' Hash ordered fields from a data frame
+hash_fields <- function(data, fields) {
+  hash_serialized_values(serialize_hash_fields(data, fields))
+}
+
+#' Hash Land Registry transaction identifiers
+hash_transaction_id <- function(transaction_id) {
+  if (anyNA(transaction_id) || any(!nzchar(as.character(transaction_id)))) {
+    stop("Land Registry transaction ids must be non-missing and non-empty.", call. = FALSE)
+  }
+  hash_fields(data.frame(transaction_id = transaction_id), "transaction_id")
+}
+
+#' Hash the locked seven-field Zoopla rental identity composite
+hash_rental_identity <- function(data) {
+  hash_fields(
+    data,
+    c(
+      "postcode", "address_line_01", "address_line_02", "address_line_03",
+      "listing_price", "latest_to_rent", "rented"
+    )
+  )
+}

--- a/scripts/R/utils/hash_utils.R
+++ b/scripts/R/utils/hash_utils.R
@@ -8,6 +8,14 @@
 HASH_NA_TOKEN <- "\u001e"
 HASH_FIELD_SEPARATOR <- "\u001f"
 
+# The locked seven-field Zoopla rental identity composite, in hash order. Every
+# consumer that hashes, deduplicates, or audits a rental identity reads this one
+# definition; the field set and its order are a public-ID contract.
+RENTAL_IDENTITY_FIELDS <- c(
+  "postcode", "address_line_01", "address_line_02", "address_line_03",
+  "listing_price", "latest_to_rent", "rented"
+)
+
 assert_hash_dependencies <- function() {
   if (!requireNamespace("digest", quietly = TRUE)) {
     stop(
@@ -23,7 +31,18 @@ format_hash_field <- function(x) {
   if (inherits(x, "Date") || inherits(x, "POSIXt")) {
     value <- format(x, "%Y-%m-%d")
   } else if (is.numeric(x)) {
-    value <- format(x, scientific = FALSE, trim = TRUE)
+    # format() derives one common format from the whole vector, so a value's
+    # text would otherwise depend on the other rows in the batch and a row's
+    # hash would not be recomputable on its own. Format each distinct value
+    # separately; mapping back is identical to formatting element by element,
+    # and costs far less on multi-million-row inputs.
+    uniques <- unique(x)
+    formatted <- vapply(
+      uniques,
+      function(v) format(v, scientific = FALSE, trim = TRUE),
+      character(1)
+    )
+    value <- formatted[match(x, uniques)]
   } else {
     value <- as.character(x)
   }
@@ -92,11 +111,5 @@ hash_transaction_id <- function(transaction_id) {
 
 #' Hash the locked seven-field Zoopla rental identity composite
 hash_rental_identity <- function(data) {
-  hash_fields(
-    data,
-    c(
-      "postcode", "address_line_01", "address_line_02", "address_line_03",
-      "listing_price", "latest_to_rent", "rented"
-    )
-  )
+  hash_fields(data, RENTAL_IDENTITY_FIELDS)
 }

--- a/scripts/R/utils/prior_exposure_utils.R
+++ b/scripts/R/utils/prior_exposure_utils.R
@@ -162,17 +162,10 @@ prior_exposure_normalize_transactions <- function(
 
   pre_filter_rows <- nrow(transactions)
   identifier <- transactions[[contract$id]]
-  valid_type <- is.character(identifier) || is.numeric(identifier)
-  invalid_numeric <- is.numeric(identifier) && any(
-    !is.na(identifier) & (!is.finite(identifier) | identifier != floor(identifier))
-  )
-  invalid_character <- is.character(identifier) && any(
-    !is.na(identifier) & !nzchar(identifier)
-  )
-  if (!valid_type || invalid_numeric || invalid_character) {
+  if (!is.character(identifier) || any(!is.na(identifier) & !nzchar(identifier))) {
     stop(
       contract$id,
-      " must contain non-empty character or whole-number transaction identifiers.",
+      " must contain non-empty character transaction identifiers.",
       call. = FALSE
     )
   }
@@ -665,10 +658,9 @@ prior_exposure_validate_and_cast_public <- function(data, expected_schema) {
         stop(column, " must be logical for Arrow bool.", call. = FALSE)
       }
     } else if (target == "string") {
-      if ((!is.character(value) && !is.numeric(value)) || anyNA(value)) {
+      if (!is.character(value) || anyNA(value) || any(!nzchar(value))) {
         stop(column, " must contain nonmissing transaction identifiers.", call. = FALSE)
       }
-      result[[column]] <- as.character(value)
     }
   }
   id <- if ("house_id" %in% names(result)) "house_id" else if (
@@ -927,13 +919,8 @@ prior_exposure_stream <- function(
   }
 
   transaction_ids <- data$transaction_dt$transaction_id
-  valid_type <- is.character(transaction_ids) || is.numeric(transaction_ids)
-  invalid_character <- is.character(transaction_ids) && any(!nzchar(transaction_ids))
-  invalid_numeric <- is.numeric(transaction_ids) && any(
-    !is.finite(transaction_ids) | transaction_ids != floor(transaction_ids)
-  )
-  if (!valid_type || anyNA(transaction_ids) || invalid_character ||
-      invalid_numeric || anyDuplicated(transaction_ids)) {
+  if (!is.character(transaction_ids) || anyNA(transaction_ids) ||
+      any(!nzchar(transaction_ids)) || anyDuplicated(transaction_ids)) {
     stop(
       "Streaming requires unique, nonmissing transaction identifiers.",
       call. = FALSE

--- a/scripts/R/utils/prior_exposure_utils.R
+++ b/scripts/R/utils/prior_exposure_utils.R
@@ -44,7 +44,7 @@ prior_exposure_public_schema <- function(market, grain) {
   switch(
     variant,
     sale_site = arrow::schema(
-      house_id = arrow::int32(),
+      house_id = arrow::utf8(),
       price = arrow::int32(),
       n_days_in_window = arrow::int32(),
       site_id = arrow::int32(),
@@ -59,7 +59,7 @@ prior_exposure_public_schema <- function(market, grain) {
       radius = arrow::int32()
     ),
     rental_site = arrow::schema(
-      rental_id = arrow::int32(),
+      rental_id = arrow::utf8(),
       listing_price = arrow::float64(),
       n_days_in_window = arrow::int32(),
       site_id = arrow::int32(),
@@ -74,7 +74,7 @@ prior_exposure_public_schema <- function(market, grain) {
       radius = arrow::int32()
     ),
     sale_radius = arrow::schema(
-      house_id = arrow::int32(),
+      house_id = arrow::utf8(),
       price = arrow::int32(),
       n_days_in_window = arrow::int32(),
       spill_hrs = arrow::float64(),
@@ -90,7 +90,7 @@ prior_exposure_public_schema <- function(market, grain) {
       radius = arrow::int32()
     ),
     rental_radius = arrow::schema(
-      rental_id = arrow::int32(),
+      rental_id = arrow::utf8(),
       listing_price = arrow::float64(),
       n_days_in_window = arrow::int32(),
       spill_hrs = arrow::float64(),
@@ -162,8 +162,19 @@ prior_exposure_normalize_transactions <- function(
 
   pre_filter_rows <- nrow(transactions)
   identifier <- transactions[[contract$id]]
-  if (!is.integer(identifier)) {
-    stop(contract$id, " must be an integer transaction identifier.", call. = FALSE)
+  valid_type <- is.character(identifier) || is.numeric(identifier)
+  invalid_numeric <- is.numeric(identifier) && any(
+    !is.na(identifier) & (!is.finite(identifier) | identifier != floor(identifier))
+  )
+  invalid_character <- is.character(identifier) && any(
+    !is.na(identifier) & !nzchar(identifier)
+  )
+  if (!valid_type || invalid_numeric || invalid_character) {
+    stop(
+      contract$id,
+      " must contain non-empty character or whole-number transaction identifiers.",
+      call. = FALSE
+    )
   }
   if (anyNA(identifier)) {
     stop(contract$id, " contains missing transaction identifiers.", call. = FALSE)
@@ -435,7 +446,7 @@ prior_exposure_reduce_site <- function(site_metrics, radii) {
 
 prior_exposure_reduce_radius <- function(site_metrics, transaction_ids, radii) {
   grid <- data.table::CJ(
-    transaction_id = as.integer(transaction_ids),
+    transaction_id = transaction_ids,
     radius = sort(radii), unique = TRUE
   )
   if (is.null(site_metrics) || nrow(site_metrics) == 0L) {
@@ -548,9 +559,9 @@ prior_exposure_project_public <- function(result, contract) {
   result[, ..columns]
 }
 
-prior_exposure_site_prototype <- function(contract) {
+prior_exposure_site_prototype <- function(contract, transaction_ids = character()) {
   result <- data.table::data.table(
-    transaction_id = integer(), transaction_value = double(),
+    transaction_id = transaction_ids[0], transaction_value = double(),
     n_days_in_window = integer(), site_id = integer(), radius = double(),
     distance_m = double(), spill_hrs = double(), spill_count = double(),
     site_missing = logical(), spill_count_daily_avg = double(),
@@ -568,7 +579,7 @@ prior_exposure_process_joined_chunk <- function(transaction_ids, data, joined) {
   if (contract$grain == "site") {
     metrics <- prior_exposure_reduce_site(site_metrics, data$config$radius_thresholds)
     if (is.null(metrics) || nrow(metrics) == 0L) {
-      return(prior_exposure_site_prototype(contract))
+      return(prior_exposure_site_prototype(contract, metadata$transaction_id))
     }
     result <- metadata[metrics, on = "transaction_id"]
     result[has_unknown_event_evidence == TRUE, `:=`(
@@ -653,6 +664,11 @@ prior_exposure_validate_and_cast_public <- function(data, expected_schema) {
       if (!is.logical(value)) {
         stop(column, " must be logical for Arrow bool.", call. = FALSE)
       }
+    } else if (target == "string") {
+      if ((!is.character(value) && !is.numeric(value)) || anyNA(value)) {
+        stop(column, " must contain nonmissing transaction identifiers.", call. = FALSE)
+      }
+      result[[column]] <- as.character(value)
     }
   }
   id <- if ("house_id" %in% names(result)) "house_id" else if (
@@ -731,7 +747,7 @@ prior_exposure_expected_chunk_keys <- function(transaction_ids, data, lookup = N
   radii <- sort(as.integer(data$config$radius_thresholds))
   if (contract$grain == "radius") {
     keys <- data.table::CJ(
-      transaction_id = as.integer(transaction_ids),
+      transaction_id = transaction_ids,
       radius = radii,
       unique = TRUE
     )
@@ -744,7 +760,9 @@ prior_exposure_expected_chunk_keys <- function(transaction_ids, data, lookup = N
     }
     if (nrow(lookup) == 0L) {
       keys <- data.table::data.table(
-        transaction_id = integer(), site_id = integer(), radius = integer()
+        transaction_id = transaction_ids[0],
+        site_id = integer(),
+        radius = integer()
       )
     } else {
       lookup <- lookup[
@@ -756,6 +774,7 @@ prior_exposure_expected_chunk_keys <- function(transaction_ids, data, lookup = N
     }
   }
   data.table::setnames(keys, "transaction_id", contract$id)
+  data.table::set(keys, j = contract$id, value = as.character(keys[[contract$id]]))
   data.table::setorderv(keys, prior_exposure_public_key_columns(contract))
   keys
 }
@@ -908,10 +927,15 @@ prior_exposure_stream <- function(
   }
 
   transaction_ids <- data$transaction_dt$transaction_id
-  if (!is.integer(transaction_ids) || anyNA(transaction_ids) ||
-      anyDuplicated(transaction_ids)) {
+  valid_type <- is.character(transaction_ids) || is.numeric(transaction_ids)
+  invalid_character <- is.character(transaction_ids) && any(!nzchar(transaction_ids))
+  invalid_numeric <- is.numeric(transaction_ids) && any(
+    !is.finite(transaction_ids) | transaction_ids != floor(transaction_ids)
+  )
+  if (!valid_type || anyNA(transaction_ids) || invalid_character ||
+      invalid_numeric || anyDuplicated(transaction_ids)) {
     stop(
-      "Streaming requires unique, nonmissing integer transaction identifiers.",
+      "Streaming requires unique, nonmissing transaction identifiers.",
       call. = FALSE
     )
   }

--- a/scripts/R/utils/repeat_transactions_utils.R
+++ b/scripts/R/utils/repeat_transactions_utils.R
@@ -105,7 +105,10 @@ validate_repeat_input <- function(data, config) {
 }
 
 build_price_ratio_review <- function(keyed, config) {
-  dt <- data.table::copy(keyed)
+  audit_cols <- c(
+    "address_key", config$id_col, config$date_col, config$price_col
+  )
+  dt <- data.table::copy(keyed[, ..audit_cols])
   data.table::setorderv(dt, c("address_key", config$date_col, config$id_col))
   dt[, `:=`(
     previous_date = data.table::shift(get(config$date_col)),
@@ -169,11 +172,17 @@ build_repeat_mapping <- function(data, config) {
     stop("repeat_id values must be lowercase 16-character hex strings.", call. = FALSE)
   }
 
-  group_counts <- keyed[, .(repeat_count = as.integer(.N)), by = .(address_key, repeat_id)]
+  group_counts <- keyed[, .(
+    repeat_count = as.integer(.N),
+    declared_count_min = min(repeat_count),
+    declared_count_max = max(repeat_count)
+  ), by = .(address_key, repeat_id)]
   if (any(group_counts$repeat_count < 1L) ||
-      !identical(sort(keyed$repeat_count), sort(group_counts$repeat_count[rep(seq_len(nrow(group_counts)), group_counts$repeat_count)]))) {
+      any(group_counts$declared_count_min != group_counts$declared_count_max) ||
+      any(group_counts$repeat_count != group_counts$declared_count_min)) {
     stop("repeat_count reconciliation failed.", call. = FALSE)
   }
+  group_counts[, c("declared_count_min", "declared_count_max") := NULL]
 
   repeat_share <- if (keyed_count == 0L) 0 else mean(keyed$repeat_count > 1L)
   if (repeat_share < config$repeat_share_floor) {
@@ -246,9 +255,14 @@ read_repeat_manifest <- function(path) {
   if (!file.exists(path)) return(NULL)
   table <- tryCatch(
     arrow::read_parquet(path, as_data_frame = FALSE),
-    error = function(e) NULL
+    error = function(e) {
+      stop(
+        "Existing repeat mapping is unreadable: ", path, ". ",
+        conditionMessage(e),
+        call. = FALSE
+      )
+    }
   )
-  if (is.null(table)) return(NULL)
   metadata <- table$metadata
   if (is.null(metadata$repeat_manifest_version) ||
       metadata$repeat_manifest_version != "1") {

--- a/scripts/R/utils/repeat_transactions_utils.R
+++ b/scripts/R/utils/repeat_transactions_utils.R
@@ -95,9 +95,11 @@ validate_repeat_input <- function(data, config) {
   }
 
   duplicate_cols <- config$duplicate_check_cols %||% character()
-  if (length(duplicate_cols) > 0L &&
-      anyDuplicated(as.data.frame(data)[duplicate_cols])) {
-    stop("Repeat input contains exact duplicates after cleaning.", call. = FALSE)
+  if (length(duplicate_cols) > 0L) {
+    duplicate_input <- data.table::as.data.table(data)[, ..duplicate_cols]
+    if (any(duplicated(duplicate_input, by = duplicate_cols))) {
+      stop("Repeat input contains exact duplicates after cleaning.", call. = FALSE)
+    }
   }
   invisible(data)
 }
@@ -112,7 +114,7 @@ build_price_ratio_review <- function(keyed, config) {
   dt[, holding_days := as.numeric(get(config$date_col) - previous_date)]
   dt[, annualized_price_ratio := {
     ratio <- get(config$price_col) / previous_price
-    fifelse(
+    data.table::fifelse(
       !is.na(ratio) & ratio > 0 & holding_days > 0,
       ratio^(365.25 / holding_days),
       NA_real_

--- a/scripts/R/utils/repeat_transactions_utils.R
+++ b/scripts/R/utils/repeat_transactions_utils.R
@@ -24,7 +24,8 @@ validate_repeat_config <- function(config) {
   required <- c(
     "id_col", "date_col", "price_col", "postcode_col", "address_cols",
     "primary_address_col", "input_path", "output_path",
-    "large_group_review_path", "price_ratio_review_path", "market",
+    "large_group_review_path", "price_ratio_review_path", "same_day_review_path",
+    "market",
     "year_min", "year_max", "key_coverage_floor", "repeat_share_floor",
     "large_group_size", "extreme_annualized_price_ratio"
   )
@@ -41,6 +42,18 @@ validate_repeat_config <- function(config) {
     stop("Coverage and repeat-share floors must lie in [0, 1].", call. = FALSE)
   }
   invisible(config)
+}
+
+#' Coerce a transaction date column to Date
+#'
+#' Sales dates arrive as POSIXct (Arrow timestamp) and rental dates as Date
+#' (Arrow date32). Date arithmetic on POSIXct yields a difftime whose unit is
+#' auto-selected from the smallest difference in the vector, so a single
+#' same-day pair silently reinterprets the whole column as seconds. Normalizing
+#' to Date removes that dependence on the data's own contents.
+as_transaction_date <- function(x) {
+  if (inherits(x, "Date")) return(x)
+  as.Date(x, tz = "UTC")
 }
 
 normalise_address_component <- function(x) {
@@ -109,12 +122,15 @@ build_price_ratio_review <- function(keyed, config) {
     "address_key", config$id_col, config$date_col, config$price_col
   )
   dt <- data.table::copy(keyed[, ..audit_cols])
+  dt[, (config$date_col) := as_transaction_date(get(config$date_col))]
   data.table::setorderv(dt, c("address_key", config$date_col, config$id_col))
   dt[, `:=`(
     previous_date = data.table::shift(get(config$date_col)),
     previous_price = data.table::shift(get(config$price_col))
   ), by = address_key]
-  dt[, holding_days := as.numeric(get(config$date_col) - previous_date)]
+  dt[, holding_days := as.numeric(
+    difftime(get(config$date_col), previous_date, units = "days")
+  )]
   dt[, annualized_price_ratio := {
     ratio <- get(config$price_col) / previous_price
     data.table::fifelse(
@@ -159,6 +175,30 @@ build_repeat_mapping <- function(data, config) {
     )
   }
 
+  # Two transactions at one address on one date contradict each other, so both
+  # sides are treated as data errors and routed to review. repeat_count is
+  # counted only over the survivors.
+  keyed[, (config$date_col) := as_transaction_date(get(config$date_col))]
+  keyed[, same_day_group_size := as.integer(.N), by = c("address_key", config$date_col)]
+  same_day_conflicts <- keyed[
+    same_day_group_size > 1L,
+    c(
+      config$id_col, "address_key", config$date_col, config$price_col,
+      "same_day_group_size"
+    ),
+    with = FALSE
+  ]
+  keyed <- keyed[same_day_group_size == 1L]
+  keyed[, same_day_group_size := NULL]
+  same_day_excluded_count <- nrow(same_day_conflicts)
+  mapped_count <- nrow(keyed)
+  if (mapped_count == 0L) {
+    stop(
+      "Every keyed row was excluded as a same-day conflict; mapping would be empty.",
+      call. = FALSE
+    )
+  }
+
   keyed[, repeat_id := hash_serialized_values(address_key)]
   keyed[, repeat_count := as.integer(.N), by = address_key]
 
@@ -184,7 +224,7 @@ build_repeat_mapping <- function(data, config) {
   }
   group_counts[, c("declared_count_min", "declared_count_max") := NULL]
 
-  repeat_share <- if (keyed_count == 0L) 0 else mean(keyed$repeat_count > 1L)
+  repeat_share <- if (mapped_count == 0L) 0 else mean(keyed$repeat_count > 1L)
   if (repeat_share < config$repeat_share_floor) {
     warning(
       sprintf(
@@ -211,6 +251,14 @@ build_repeat_mapping <- function(data, config) {
     }
   }
 
+  if (same_day_excluded_count > 0L) {
+    warning(
+      same_day_excluded_count,
+      " row(s) excluded as same-day repeat conflicts and routed to review.",
+      call. = FALSE
+    )
+  }
+
   large_groups <- group_counts[repeat_count > as.integer(config$large_group_size)]
   price_ratio_issues <- build_price_ratio_review(keyed, config)
   if (nrow(price_ratio_issues) > 0L) {
@@ -233,13 +281,16 @@ build_repeat_mapping <- function(data, config) {
       input_count = as.integer(input_count),
       keyed_count = as.integer(keyed_count),
       excluded_count = as.integer(excluded_count),
+      same_day_excluded_count = as.integer(same_day_excluded_count),
+      mapped_count = as.integer(mapped_count),
       key_coverage = key_coverage,
       repeat_share = repeat_share,
       largest_group_size = if (nrow(group_counts) == 0L) 0L else max(group_counts$repeat_count)
     ),
     large_groups = large_groups[],
     property_type_issues = property_type_issues[],
-    price_ratio_issues = price_ratio_issues[]
+    price_ratio_issues = price_ratio_issues[],
+    same_day_conflicts = same_day_conflicts[]
   )
 }
 
@@ -286,6 +337,8 @@ build_repeat_manifest <- function(config, metrics) {
     run_timestamp = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
     keyed_count = as.character(metrics$keyed_count),
     excluded_count = as.character(metrics$excluded_count),
+    same_day_excluded_count = as.character(metrics$same_day_excluded_count),
+    mapped_count = as.character(metrics$mapped_count),
     key_coverage = sprintf("%.8f", metrics$key_coverage),
     repeat_share = sprintf("%.8f", metrics$repeat_share),
     largest_group_size = as.character(metrics$largest_group_size),
@@ -314,11 +367,20 @@ log_manifest_delta <- function(previous, current, log_fn = NULL) {
     return(invisible(NULL))
   }
   fields <- c(
-    "input_row_count", "keyed_count", "excluded_count", "key_coverage",
-    "repeat_share", "largest_group_size"
+    "input_row_count", "keyed_count", "excluded_count", "same_day_excluded_count",
+    "mapped_count", "key_coverage", "repeat_share", "largest_group_size"
   )
+  # Index field by field: a manifest written before a field existed would
+  # otherwise drop a NULL and shift every remaining pair out of alignment.
+  manifest_values <- function(manifest) {
+    vapply(
+      fields,
+      function(field) as.character(manifest[[field]] %||% "absent"),
+      character(1)
+    )
+  }
   delta <- paste(
-    sprintf("%s=%s->%s", fields, unlist(previous[fields]), unlist(current[fields])),
+    sprintf("%s=%s->%s", fields, manifest_values(previous), manifest_values(current)),
     collapse = "; "
   )
   emit_repeat_log("INFO", paste("Manifest delta:", delta), log_fn)
@@ -344,6 +406,7 @@ write_repeat_outputs <- function(result, config, manifest) {
   write_arrow_table_atomic(table, config$output_path)
   write_arrow_table_atomic(as.data.frame(result$large_groups), config$large_group_review_path)
   write_arrow_table_atomic(as.data.frame(result$price_ratio_issues), config$price_ratio_review_path)
+  write_arrow_table_atomic(as.data.frame(result$same_day_conflicts), config$same_day_review_path)
   invisible(config$output_path)
 }
 
@@ -381,10 +444,14 @@ run_repeat_transactions <- function(config, data = NULL, log_fn = NULL) {
   emit_repeat_log(
     "INFO",
     sprintf(
-      "Mapped %d of %d rows; excluded %d (coverage %.4f; repeat share %.4f).",
-      result$metrics$keyed_count,
+      paste(
+        "Mapped %d of %d rows; excluded %d unkeyed and %d same-day",
+        "(coverage %.4f; repeat share %.4f)."
+      ),
+      result$metrics$mapped_count,
       result$metrics$input_count,
       result$metrics$excluded_count,
+      result$metrics$same_day_excluded_count,
       result$metrics$key_coverage,
       result$metrics$repeat_share
     ),

--- a/scripts/R/utils/repeat_transactions_utils.R
+++ b/scripts/R/utils/repeat_transactions_utils.R
@@ -23,7 +23,7 @@ assert_repeat_dependencies <- function() {
 validate_repeat_config <- function(config) {
   required <- c(
     "id_col", "date_col", "price_col", "postcode_col", "address_cols",
-    "primary_address_col", "input_path", "output_path",
+    "primary_address_col", "input_path", "output_path", "log_file",
     "large_group_review_path", "price_ratio_review_path", "same_day_review_path",
     "market",
     "year_min", "year_max", "key_coverage_floor", "repeat_share_floor",

--- a/scripts/R/utils/repeat_transactions_utils.R
+++ b/scripts/R/utils/repeat_transactions_utils.R
@@ -1,0 +1,380 @@
+# ==============================================================================
+# Shared Repeat-Transaction Pipeline
+# ==============================================================================
+
+# repeat_count is always computed over the full configured long-run input.
+# Consumers that restrict the date window must regroup the mapping after their
+# window filter; the persisted repeat_count must not be treated as window-local.
+
+`%||%` <- function(x, y) if (is.null(x)) y else x
+
+assert_repeat_dependencies <- function() {
+  required <- c("arrow", "data.table", "logger", "lubridate", "tidyselect")
+  missing <- required[!vapply(required, requireNamespace, quietly = TRUE, FUN.VALUE = logical(1))]
+  if (length(missing) > 0L) {
+    stop(
+      "Missing required packages: ", paste(missing, collapse = ", "),
+      ". Install project dependencies first with `rv sync`.",
+      call. = FALSE
+    )
+  }
+}
+
+validate_repeat_config <- function(config) {
+  required <- c(
+    "id_col", "date_col", "price_col", "postcode_col", "address_cols",
+    "primary_address_col", "input_path", "output_path",
+    "large_group_review_path", "price_ratio_review_path", "market",
+    "year_min", "year_max", "key_coverage_floor", "repeat_share_floor",
+    "large_group_size", "extreme_annualized_price_ratio"
+  )
+  missing <- required[!vapply(required, function(name) !is.null(config[[name]]), logical(1))]
+  if (length(missing) > 0L) {
+    stop("Missing repeat config values: ", paste(missing, collapse = ", "), call. = FALSE)
+  }
+  if (!config$postcode_col %in% config$address_cols ||
+      !config$primary_address_col %in% config$address_cols) {
+    stop("Address columns must include postcode and primary address fields.", call. = FALSE)
+  }
+  if (config$key_coverage_floor < 0 || config$key_coverage_floor > 1 ||
+      config$repeat_share_floor < 0 || config$repeat_share_floor > 1) {
+    stop("Coverage and repeat-share floors must lie in [0, 1].", call. = FALSE)
+  }
+  invisible(config)
+}
+
+normalise_address_component <- function(x) {
+  value <- enc2utf8(as.character(x))
+  value[is.na(value)] <- ""
+  value <- toupper(value)
+  value <- gsub("[[:punct:]]+", "", value)
+  value <- gsub("[[:space:]]+", " ", value)
+  trimws(value)
+}
+
+build_address_key <- function(data, config) {
+  validate_repeat_config(config)
+  missing <- setdiff(config$address_cols, names(data))
+  if (length(missing) > 0L) {
+    stop("Missing address columns: ", paste(missing, collapse = ", "), call. = FALSE)
+  }
+
+  components <- lapply(as.data.frame(data)[config$address_cols], normalise_address_component)
+  names(components) <- config$address_cols
+  postcode <- components[[config$postcode_col]]
+  primary <- components[[config$primary_address_col]]
+  key <- do.call(paste, c(components, sep = "|"))
+  key[postcode == "" | primary == ""] <- NA_character_
+  key
+}
+
+validate_repeat_input <- function(data, config) {
+  required <- unique(c(
+    config$id_col, config$date_col, config$price_col, config$address_cols,
+    config$property_type_col %||% character(),
+    config$duplicate_check_cols %||% character()
+  ))
+  missing <- setdiff(required, names(data))
+  if (length(missing) > 0L) {
+    stop("Missing repeat input columns: ", paste(missing, collapse = ", "), call. = FALSE)
+  }
+  if (nrow(data) == 0L) stop("Repeat input must be non-empty.", call. = FALSE)
+
+  ids <- data[[config$id_col]]
+  if (anyNA(ids) || any(!nzchar(as.character(ids))) || anyDuplicated(ids)) {
+    stop("Repeat input transaction ids must be non-missing and unique.", call. = FALSE)
+  }
+
+  dates <- as.Date(data[[config$date_col]])
+  years <- lubridate::year(dates)
+  if (anyNA(years) || any(years < config$year_min | years > config$year_max)) {
+    stop(
+      "Repeat input dates must fall within ", config$year_min, "-", config$year_max, ".",
+      call. = FALSE
+    )
+  }
+
+  duplicate_cols <- config$duplicate_check_cols %||% character()
+  if (length(duplicate_cols) > 0L &&
+      anyDuplicated(as.data.frame(data)[duplicate_cols])) {
+    stop("Repeat input contains exact duplicates after cleaning.", call. = FALSE)
+  }
+  invisible(data)
+}
+
+build_price_ratio_review <- function(keyed, config) {
+  dt <- data.table::copy(keyed)
+  data.table::setorderv(dt, c("address_key", config$date_col, config$id_col))
+  dt[, `:=`(
+    previous_date = data.table::shift(get(config$date_col)),
+    previous_price = data.table::shift(get(config$price_col))
+  ), by = address_key]
+  dt[, holding_days := as.numeric(get(config$date_col) - previous_date)]
+  dt[, annualized_price_ratio := {
+    ratio <- get(config$price_col) / previous_price
+    fifelse(
+      !is.na(ratio) & ratio > 0 & holding_days > 0,
+      ratio^(365.25 / holding_days),
+      NA_real_
+    )
+  }]
+  threshold <- config$extreme_annualized_price_ratio
+  dt[
+    !is.na(annualized_price_ratio) &
+      (annualized_price_ratio > threshold | annualized_price_ratio < 1 / threshold),
+    c(
+      config$id_col, "address_key", config$date_col, config$price_col,
+      "previous_date", "previous_price", "holding_days", "annualized_price_ratio"
+    ),
+    with = FALSE
+  ]
+}
+
+#' Build a repeat mapping and its diagnostics without writing files
+build_repeat_mapping <- function(data, config) {
+  assert_repeat_dependencies()
+  validate_repeat_config(config)
+  validate_repeat_input(data, config)
+
+  dt <- data.table::as.data.table(data.table::copy(data))
+  dt[, address_key := build_address_key(.SD, config)]
+
+  input_count <- nrow(dt)
+  keyed <- dt[!is.na(address_key)]
+  keyed_count <- nrow(keyed)
+  excluded_count <- input_count - keyed_count
+  key_coverage <- keyed_count / input_count
+  if (key_coverage < config$key_coverage_floor) {
+    stop(
+      sprintf(
+        "Key coverage %.6f is below configured floor %.6f.",
+        key_coverage, config$key_coverage_floor
+      ),
+      call. = FALSE
+    )
+  }
+
+  keyed[, repeat_id := hash_serialized_values(address_key)]
+  keyed[, repeat_count := as.integer(.N), by = address_key]
+
+  if (data.table::uniqueN(keyed$address_key) != data.table::uniqueN(keyed$repeat_id)) {
+    stop("Distinct address keys did not map one-to-one to repeat ids.", call. = FALSE)
+  }
+  if (anyDuplicated(keyed[[config$id_col]])) {
+    stop("Repeat mapping transaction ids are not unique.", call. = FALSE)
+  }
+  if (any(!grepl("^[0-9a-f]{16}$", keyed$repeat_id))) {
+    stop("repeat_id values must be lowercase 16-character hex strings.", call. = FALSE)
+  }
+
+  group_counts <- keyed[, .(repeat_count = as.integer(.N)), by = .(address_key, repeat_id)]
+  if (any(group_counts$repeat_count < 1L) ||
+      !identical(sort(keyed$repeat_count), sort(group_counts$repeat_count[rep(seq_len(nrow(group_counts)), group_counts$repeat_count)]))) {
+    stop("repeat_count reconciliation failed.", call. = FALSE)
+  }
+
+  repeat_share <- if (keyed_count == 0L) 0 else mean(keyed$repeat_count > 1L)
+  if (repeat_share < config$repeat_share_floor) {
+    warning(
+      sprintf(
+        "Repeat share %.6f is below configured floor %.6f.",
+        repeat_share, config$repeat_share_floor
+      ),
+      call. = FALSE
+    )
+  }
+
+  property_type_issues <- data.table::data.table()
+  property_type_col <- config$property_type_col %||% NULL
+  if (!is.null(property_type_col)) {
+    property_type_issues <- keyed[
+      , .(property_type_count = data.table::uniqueN(na.omit(get(property_type_col)))),
+      by = .(address_key, repeat_id)
+    ][property_type_count > 1L]
+    if (nrow(property_type_issues) > 0L) {
+      warning(
+        nrow(property_type_issues),
+        " repeat group(s) contain more than one property type.",
+        call. = FALSE
+      )
+    }
+  }
+
+  large_groups <- group_counts[repeat_count > as.integer(config$large_group_size)]
+  price_ratio_issues <- build_price_ratio_review(keyed, config)
+  if (nrow(price_ratio_issues) > 0L) {
+    warning(
+      nrow(price_ratio_issues),
+      " extreme annualized price-ratio pair(s) routed to review.",
+      call. = FALSE
+    )
+  }
+
+  mapping <- keyed[, c(config$id_col, "repeat_id", "repeat_count"), with = FALSE]
+  mapping[, (config$id_col) := as.character(get(config$id_col))]
+  mapping[, repeat_id := as.character(repeat_id)]
+  mapping[, repeat_count := as.integer(repeat_count)]
+
+  list(
+    mapping = mapping[],
+    keyed_data = keyed[],
+    metrics = list(
+      input_count = as.integer(input_count),
+      keyed_count = as.integer(keyed_count),
+      excluded_count = as.integer(excluded_count),
+      key_coverage = key_coverage,
+      repeat_share = repeat_share,
+      largest_group_size = if (nrow(group_counts) == 0L) 0L else max(group_counts$repeat_count)
+    ),
+    large_groups = large_groups[],
+    property_type_issues = property_type_issues[],
+    price_ratio_issues = price_ratio_issues[]
+  )
+}
+
+repeat_mapping_schema <- function(id_col) {
+  arrow::schema(
+    arrow::field(id_col, arrow::utf8()),
+    arrow::field("repeat_id", arrow::utf8()),
+    arrow::field("repeat_count", arrow::int32())
+  )
+}
+
+read_repeat_manifest <- function(path) {
+  if (!file.exists(path)) return(NULL)
+  table <- tryCatch(
+    arrow::read_parquet(path, as_data_frame = FALSE),
+    error = function(e) NULL
+  )
+  if (is.null(table)) return(NULL)
+  metadata <- table$metadata
+  if (is.null(metadata$repeat_manifest_version) ||
+      metadata$repeat_manifest_version != "1") {
+    return(NULL)
+  }
+  metadata
+}
+
+build_repeat_manifest <- function(config, metrics) {
+  input_path <- normalizePath(config$input_path, mustWork = FALSE)
+  input_mtime <- if (file.exists(config$input_path)) {
+    format(file.info(config$input_path)$mtime, "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+  } else {
+    "in-memory"
+  }
+  list(
+    repeat_manifest_version = "1",
+    input_path = input_path,
+    input_row_count = as.character(metrics$input_count),
+    input_mtime = input_mtime,
+    run_timestamp = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+    keyed_count = as.character(metrics$keyed_count),
+    excluded_count = as.character(metrics$excluded_count),
+    key_coverage = sprintf("%.8f", metrics$key_coverage),
+    repeat_share = sprintf("%.8f", metrics$repeat_share),
+    largest_group_size = as.character(metrics$largest_group_size),
+    market = as.character(config$market),
+    repeat_count_semantics = "full_long_run_input"
+  )
+}
+
+emit_repeat_log <- function(level, message, log_fn = NULL) {
+  if (!is.null(log_fn)) {
+    log_fn(level, message)
+    return(invisible(message))
+  }
+  switch(
+    level,
+    WARN = logger::log_warn(message),
+    ERROR = logger::log_error(message),
+    logger::log_info(message)
+  )
+  invisible(message)
+}
+
+log_manifest_delta <- function(previous, current, log_fn = NULL) {
+  if (is.null(previous) || previous$market != current$market) {
+    emit_repeat_log("INFO", "Manifest diff skipped: first generation.", log_fn)
+    return(invisible(NULL))
+  }
+  fields <- c(
+    "input_row_count", "keyed_count", "excluded_count", "key_coverage",
+    "repeat_share", "largest_group_size"
+  )
+  delta <- paste(
+    sprintf("%s=%s->%s", fields, unlist(previous[fields]), unlist(current[fields])),
+    collapse = "; "
+  )
+  emit_repeat_log("INFO", paste("Manifest delta:", delta), log_fn)
+}
+
+write_arrow_table_atomic <- function(table, path) {
+  dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
+  tmp <- tempfile(pattern = paste0(".", basename(path), "-"), tmpdir = dirname(path), fileext = ".parquet")
+  on.exit(unlink(tmp), add = TRUE)
+  arrow::write_parquet(table, tmp)
+  if (!file.rename(tmp, path)) {
+    stop("Failed to promote staged parquet to ", path, ".", call. = FALSE)
+  }
+  invisible(path)
+}
+
+write_repeat_outputs <- function(result, config, manifest) {
+  table <- arrow::Table$create(
+    as.data.frame(result$mapping),
+    schema = repeat_mapping_schema(config$id_col)
+  )
+  table$metadata <- manifest
+  write_arrow_table_atomic(table, config$output_path)
+  write_arrow_table_atomic(as.data.frame(result$large_groups), config$large_group_review_path)
+  write_arrow_table_atomic(as.data.frame(result$price_ratio_issues), config$price_ratio_review_path)
+  invisible(config$output_path)
+}
+
+load_repeat_input <- function(config) {
+  selected <- unique(c(
+    config$id_col, config$date_col, config$price_col, config$address_cols,
+    config$property_type_col %||% character(),
+    config$duplicate_check_cols %||% character()
+  ))
+  data.table::as.data.table(
+    arrow::read_parquet(
+      config$input_path,
+      col_select = tidyselect::all_of(selected)
+    )
+  )
+}
+
+#' Run the configured repeat-transaction pipeline
+run_repeat_transactions <- function(config, data = NULL, log_fn = NULL) {
+  assert_repeat_dependencies()
+  validate_repeat_config(config)
+  previous_manifest_path <- config$previous_manifest_path %||% config$output_path
+  previous_manifest <- read_repeat_manifest(previous_manifest_path)
+  input <- if (is.null(data)) load_repeat_input(config) else data
+
+  result <- withCallingHandlers(
+    build_repeat_mapping(input, config),
+    warning = function(w) {
+      emit_repeat_log("WARN", conditionMessage(w), log_fn)
+      invokeRestart("muffleWarning")
+    }
+  )
+  manifest <- build_repeat_manifest(config, result$metrics)
+  log_manifest_delta(previous_manifest, manifest, log_fn)
+  emit_repeat_log(
+    "INFO",
+    sprintf(
+      "Mapped %d of %d rows; excluded %d (coverage %.4f; repeat share %.4f).",
+      result$metrics$keyed_count,
+      result$metrics$input_count,
+      result$metrics$excluded_count,
+      result$metrics$key_coverage,
+      result$metrics$repeat_share
+    ),
+    log_fn
+  )
+  write_repeat_outputs(result, config, manifest)
+  result$manifest <- manifest
+  invisible(result)
+}

--- a/todos/2026-07-07-review-repeat-rentals-sales.md
+++ b/todos/2026-07-07-review-repeat-rentals-sales.md
@@ -7,11 +7,33 @@
 
 **Status key:** `[ ]` open · `[x]` fixed · `[-]` won't fix (note why)
 
+> **Note (2026-08-14):** the rebuild these findings feed is now specified by `docs/plans/2026-08-14-001-refactor-repeat-transactions-consolidated-rebuild-plan.md` (superseding the 2026-07-07 plan). Finding 1's rentals evidence was superseded by the 2026-08-12 rerun — the staleness is now on the sales side. Findings get checked off by that plan's U6.
+
+### U6 closeout sweep (2026-08-15)
+
+- Every live analysis reference to the removed Land Registry source column was
+  eliminated. Remaining `transaction_id` names are confined to the cleaner,
+  its historical reconciliation gate, hash/producer helpers that use the term
+  generically, and isolated fixture-local variables.
+- The live repeat estimator and the repeat-purchase notebooks join the canonical
+  long-run mappings to their study-window transactions, then regroup by
+  `repeat_id`; no window-restricted consumer trusts persisted long-run
+  `repeat_count`.
+- `00_data_load`, `01_descriptive`, and `05_news` contain no integer casts,
+  arithmetic, sequence generation, or Arrow integer schema pins for
+  `house_id`/`rental_id`; their joins remain direct string-key joins.
+- All five affected hedonic analyses reran successfully. The twelve
+  upstream/downstream analyses parsed cleanly but could not be replayed because
+  their required untracked river-direction CSV inputs under
+  `upstream_downstream/output/{03-02,18-03}/river_filter/` are absent.
+
 ---
 
 ## High
 
-### 1. `[ ]` Shipped rentals mapping is stale and provably misaligned with the regenerated input — active data corruption
+### 1. `[x]` Shipped rentals mapping is stale and provably misaligned with the regenerated input — active data corruption
+
+- **Status (2026-08-15):** fixed by content-stable transaction IDs, full mapping regeneration, and an exhaustive verifier showing zero unmatched IDs in both long-run mappings.
 
 - **Where:** `repeat_rentals.R:180-211` (`export_repeat_ids`) writes `(rental_id, repeat_id)` keyed on a positional row number; consumer `scripts/R/09_analysis/03_repeat_sales/repeat_sales.R:99,123` inner-joins by that id. Root cause: `rental_id`/`house_id` are `row_number()` ids (`clean_zoopla_data.R:262`, `clean_lr_house_price_data.R:219`) with no provenance guard anywhere.
 - **Problem:** the mapping parquets on disk predate the March 2026 regeneration of both inputs (`repeated_rentals.parquet` is from October 2025, `repeated_sales.parquet` from December 2025; both inputs from March 2026). Because the ids are positional, any change in upstream row count or order silently re-labels every transaction.
@@ -19,7 +41,9 @@
 - **Suggested fix:** regenerate both mappings immediately after any upstream rebuild (and now). In the rebuild, export a content-stable key alongside `repeat_id` (sales already has the Land Registry `transaction_id` string; rentals can carry the address key or a hash of it), or write the input row count into the parquet metadata and make consumers assert it.
 - **Flagged by:** adversarial; proven active by validator execution.
 
-### 2. `[ ]` Properties with no spill site within the lookup radius silently vanish from every distance band in the summary
+### 2. `[x]` Properties with no spill site within the lookup radius silently vanish from every distance band in the summary
+
+- **Status (2026-08-15):** fixed by removing the unconsumed distance-summary stage; spatial review is no longer mixed into repeat identification.
 
 - **Where:** `repeat_rentals.R:220-232` (`load_spill_lookup`) and `repeat_sales.R:215-227`; consumed by `generate_summary` in both twins.
 - **Problem:** the spill lookups contain one row for **every** property; those with no site within the radius carry `NA` distance (not absent rows). Arrow's `summarise(min(distance_m, na.rm = TRUE))` returns `NA` for an all-`NA` group — silently, with no warning, unlike base R which returns `Inf` with a warning. All four distance flags then evaluate to `NA`, and `any(flag, na.rm = TRUE)` in the summary turns them into `FALSE` in every band. Those properties are counted in `n_properties` but belong to no band, so every `share_*` column is silently deflated.
@@ -27,7 +51,9 @@
 - **Suggested fix:** after `collect()`, map `NA` minimum distance to an explicit `beyond_radius` flag (or `Inf`) so the truncation is visible, and make the four bands plus `beyond_radius` a complete partition. Decide in the rebuild whether this diagnostic survives at all (see finding 8).
 - **Flagged by:** adversarial (empirically), correctness and maintainability (same phenomenon, different mechanism guess); mechanism pinned down and confirmed by validator execution.
 
-### 3. `[ ]` Right join in `generate_summary` pools every mapping-absent id into one fake property — active for rentals on next rerun
+### 3. `[x]` Right join in `generate_summary` pools every mapping-absent id into one fake property — active for rentals on next rerun
+
+- **Status (2026-08-15):** fixed with the summary-stage removal. Mapping attrition is now explicit in manifest `keyed_count`, `excluded_count`, and `key_coverage` fields.
 
 - **Where:** `repeat_rentals.R:255-267` and `repeat_sales.R:250-262`: `rentals_dt[spill_lookup, on = "rental_id", nomatch = NA]` keeps every lookup row; lookup ids missing from the mapping survive with `repeat_id = NA` and the `by = repeat_id` aggregation pools them into a single pseudo-property.
 - **Problem:** transactions whose address key is `NA` are excluded from the exported mapping, but they are present in the spill lookup. Every such id lands in one `NA` group whose transaction count is their total number, polluting the top of the repeat-count distribution.
@@ -35,7 +61,9 @@
 - **Suggested fix:** drive the join from the mapping side (or use `nomatch = NULL`) and log the excluded count; add `stopifnot(!anyNA(summary_dt$repeat_id))` after the join in both twins.
 - **Flagged by:** correctness, testing, adversarial (independently); activation counts established by validator execution.
 
-### 4. `[ ]` The two scripts are one script written twice — parameterize in the rebuild
+### 4. `[x]` The two scripts are one script written twice — parameterize in the rebuild
+
+- **Status (2026-08-15):** fixed; both entry scripts now provide configuration to `scripts/R/utils/repeat_transactions_utils.R`.
 
 - **Where:** both files, whole-script.
 - **Problem:** the twins are structurally identical (same eight functions, same control flow); only about 18% of combined lines differ, all renames, column names, and paths. Every defect in this review exists twice and every fix must be applied twice; this directory already demonstrates the fork-and-diverge failure mode (see the sibling review of 2026-07-07, finding 3, a one-twin-only copy-paste slip).
@@ -45,7 +73,9 @@
 
 ## Moderate
 
-### 5. `[ ]` `max()` on an empty repeat set produces `-Inf` repeat ids for every single-transaction property (latent edge case)
+### 5. `[x]` `max()` on an empty repeat set produces `-Inf` repeat ids for every single-transaction property (latent edge case)
+
+- **Status (2026-08-15):** fixed by deterministic address-key hashing; empty and all-single inputs no longer depend on numeric maxima or sequence allocation.
 
 - **Where:** `repeat_rentals.R:192` and `repeat_sales.R:187` (`max_repeat_id <- max(repeated_output$repeat_id)`).
 - **Problem:** if no property ever repeats (empty input, filtered subsample, schema drift upstream), `max()` of an empty vector returns `-Inf` with only a console warning that the file-based logger does not capture. Every single then gets `repeat_id = -Inf + seq_len(.N)`, the export succeeds, and the downstream `filter(n() > 1)` keeps the entire singles set as one fake property.
@@ -53,28 +83,36 @@
 - **Suggested fix:** `max_repeat_id <- if (nrow(repeated_output) > 0L) max(repeated_output$repeat_id) else 0L`, plus `stopifnot(all(is.finite(all_output$repeat_id)))` before the write.
 - **Flagged by:** correctness, testing, adversarial (independently); verified by the orchestrator.
 
-### 6. `[ ]` Full-width loads and full-width intermediate copies waste roughly a gigabyte of peak memory per run
+### 6. `[x]` Full-width loads and full-width intermediate copies waste roughly a gigabyte of peak memory per run
+
+- **Status (2026-08-15):** fixed; the shared loader projects only configured identity, date, price, address, property-type, and duplicate-check columns.
 
 - **Where:** `repeat_rentals.R:90` and `repeat_sales.R:88` (`rio::import` reads all 32 and 31 columns when only 7–8 are used); `repeat_rentals.R:186-196` and `repeat_sales.R:181-191` (`repeat_dt`/`single_dt` are full-width copies made only to derive two columns).
 - **Evidence (verified by execution):** the sales table is ~1.12 GB in memory; the two intermediate copies transiently add ~1.27 GB. Column pruning was verified against the actual parquet schemas. The one-step alternative (`dt[filter, .(id, repeat_id = .GRP), by = simple_key]`) was verified to produce the identical id-to-group partition.
 - **Suggested fix:** `arrow::read_parquet(path, col_select = ...)` plus `setDT()` at load; compute the projection inside a single data.table call in `export_repeat_ids`. Both belong in the rebuild together.
 - **Flagged by:** performance; equivalence and magnitudes confirmed by validator execution.
 
-### 7. `[ ]` Dead code and dead columns: the all-`NA` key regex can never fire, and six computed columns are never read
+### 7. `[x]` Dead code and dead columns: the all-`NA` key regex can never fire, and six computed columns are never read
+
+- **Status (2026-08-15):** fixed; the shared module computes only the persisted mapping and the two explicit review diagnostics.
 
 - **Where:** regex cleanup at `repeat_rentals.R:130` and `repeat_sales.R:125`; computed columns (`*_sequence`, `lag_date`, `lag_price`, `holding_period_days`, `price_change`, `pct_change`) at `repeat_rentals.R:146-168` and `repeat_sales.R:141-163`.
 - **Problem:** the `fifelse` guard already forces the first key component to be real text, so `^(NA\|)*NA$` can only match if a cleaned field is the literal string `"NA"` — which occurs zero times in either full dataset (verified). The six per-transaction columns are exported nowhere and read by nothing (the downstream consumer selects only the id and `repeat_id`); the Palmquist script recomputes pairs itself.
 - **Suggested fix:** delete the regex lines. In the rebuild, either compute only what is exported, or deliberately export the pair metrics if a consumer is planned — decide in the grilling session.
 - **Flagged by:** maintainability (both at maximum confidence); data check by validator; consumer check by the orchestrator.
 
-### 8. `[ ]` The distance summary measures different things in the two twins and nothing consumes it
+### 8. `[x]` The distance summary measures different things in the two twins and nothing consumes it
+
+- **Status (2026-08-15):** fixed by retiring the summary outputs and archiving the legacy files; repeat construction no longer reads spill lookups.
 
 - **Where:** `generate_summary`/`export_summary` in both twins; flags at `repeat_rentals.R:227-232` and `repeat_sales.R:222-227`.
 - **Problem:** the rentals lookup extends to 5 km and the sales lookup to 10 km (verified maxima 4,999.7 m and 9,998.1 m), despite both builder scripts being named "10km". So `outside_1000m` means "between 1 km and 5 km" for rentals but "between 1 km and 10 km" for sales, and the two summary parquets are not comparable. Separately, no script reads either summary output — they are human diagnostics only.
 - **Suggested fix:** decide in the rebuild whether the summary stage survives. If it does: drive it from the mapping, name the bands honestly, assert the expected lookup radius at load so a regenerated lookup fails loudly. Note the radius mismatch is already flagged as a pending P0 in `todos/012-pending-p0-review-10km-site-match-scripts.md`.
 - **Flagged by:** adversarial (empirically), maintainability; radii confirmed by validator.
 
-### 9. `[ ]` Address keys embed the literal string "NA", so inconsistent secondary-address fields split true repeat pairs
+### 9. `[x]` Address keys embed the literal string "NA", so inconsistent secondary-address fields split true repeat pairs
+
+- **Status (2026-08-15):** fixed; every address component now maps missing values to the empty string before normalization and key construction, while missing postcode or primary address remains explicit mapping attrition.
 
 - **Where:** `repeat_rentals.R:117-127` and `repeat_sales.R:115-121` (`paste(..., sep = "|")` over fields that may be `NA`).
 - **Problem:** `paste()` renders `NA` as the text `"NA"`. A house sold once with `saon` missing and once with `saon` filled gets two different keys and is missed as a repeat pair. This is systematic under-matching (Land Registry `saon` is missing for most non-flat records), and it interacts with a documented history of postcode-completeness regressions upstream.
@@ -82,7 +120,9 @@
 - **Suggested fix:** a methodological decision for the grilling session, not a mechanical patch: choose the key fields deliberately (for example postcode + paon + saon with explicit missing-handling), quantify both under-matching (splits) and over-merging (coarse keys) before committing, and consider cross-checking merged keys against coordinates.
 - **Flagged by:** correctness, adversarial; quantified by validator.
 
-### 10. `[ ]` No output-contract checks despite the repo having a contract-test convention
+### 10. `[x]` No output-contract checks despite the repo having a contract-test convention
+
+- **Status (2026-08-15):** fixed with fixture contracts, strict Arrow schemas, row/key reconciliation, manifest thresholds, deterministic rerun checks, and production 100% source-match verification.
 
 - **Where:** both scripts, `export_repeat_ids` and `main`.
 - **Problem:** the exported mapping is a join key for the paper's repeat-transaction regressions, yet nothing asserts id uniqueness, row-count reconciliation against keyed input rows, finiteness of `repeat_id`, or a minimum address-key match rate. The repo already has the convention (`scripts/R/testing/test_merge_outputs_contracts.R`, `test_aggregate_spill_stats_crosswalk_contracts.R`); these two scripts predate it. A small fixture test would have caught findings 3 and 5.

--- a/todos/2026-07-07-review-repeat-rentals-sales.md
+++ b/todos/2026-07-07-review-repeat-rentals-sales.md
@@ -1,0 +1,105 @@
+# Code review — `repeat_rentals.R` and `repeat_sales.R`
+
+- **Date:** 2026-07-07
+- **Scope:** whole-file sanity check of `scripts/R/06_analysis_datasets/repeat_rentals.R` and `scripts/R/06_analysis_datasets/repeat_sales.R` (near-identical twins), verified against the actual parquet inputs (`zoopla_rentals.parquet`, `house_price.parquet`, `spill_rental_lookup.parquet`, `spill_house_lookup.parquet`), the shipped mapping outputs under `data/processed/repeated_transactions/`, and the downstream consumer `scripts/R/09_analysis/03_repeat_sales/repeat_sales.R`.
+- **Method:** eight parallel review agents (correctness, adversarial, performance, testing, maintainability, project standards, agent-native, learnings research), followed by seven independent validator agents that re-verified every load-bearing finding by direct execution against the real data. One finding was rejected in validation and is recorded at the bottom.
+- **Verdict:** the core repeat-identification logic (ordering, grouping, sequencing) is sound, but the pipeline around it has one active data-integrity failure and one corrupted diagnostic. The shipped rentals mapping is **provably misaligned with the current input data** (finding 1) — any repeat-rental result produced from the current on-disk files is joining repeat groups to the wrong transactions. The distance summary silently misclassifies every property that has no spill site within the lookup radius (finding 2) and, on the next rerun, will pool 31,836 unmatched rentals into one fake property (finding 3). The planned rebuild is well justified; findings 4–10 should shape it rather than be patched piecemeal.
+
+**Status key:** `[ ]` open · `[x]` fixed · `[-]` won't fix (note why)
+
+---
+
+## High
+
+### 1. `[ ]` Shipped rentals mapping is stale and provably misaligned with the regenerated input — active data corruption
+
+- **Where:** `repeat_rentals.R:180-211` (`export_repeat_ids`) writes `(rental_id, repeat_id)` keyed on a positional row number; consumer `scripts/R/09_analysis/03_repeat_sales/repeat_sales.R:99,123` inner-joins by that id. Root cause: `rental_id`/`house_id` are `row_number()` ids (`clean_zoopla_data.R:262`, `clean_lr_house_price_data.R:219`) with no provenance guard anywhere.
+- **Problem:** the mapping parquets on disk predate the March 2026 regeneration of both inputs (`repeated_rentals.parquet` is from October 2025, `repeated_sales.parquet` from December 2025; both inputs from March 2026). Because the ids are positional, any change in upstream row count or order silently re-labels every transaction.
+- **Evidence (verified by execution):** `repeated_rentals.parquet` has a maximum `rental_id` of 1,451,521 while the current `zoopla_rentals.parquet` has only 1,450,255 rows; 1,266 mapped ids do not exist in the current input at all. The upstream row set demonstrably changed after the mapping was built. The sales side reconciles exactly (maximum `house_id` equals the current row count), so it is latent there, not proven broken.
+- **Suggested fix:** regenerate both mappings immediately after any upstream rebuild (and now). In the rebuild, export a content-stable key alongside `repeat_id` (sales already has the Land Registry `transaction_id` string; rentals can carry the address key or a hash of it), or write the input row count into the parquet metadata and make consumers assert it.
+- **Flagged by:** adversarial; proven active by validator execution.
+
+### 2. `[ ]` Properties with no spill site within the lookup radius silently vanish from every distance band in the summary
+
+- **Where:** `repeat_rentals.R:220-232` (`load_spill_lookup`) and `repeat_sales.R:215-227`; consumed by `generate_summary` in both twins.
+- **Problem:** the spill lookups contain one row for **every** property; those with no site within the radius carry `NA` distance (not absent rows). Arrow's `summarise(min(distance_m, na.rm = TRUE))` returns `NA` for an all-`NA` group — silently, with no warning, unlike base R which returns `Inf` with a warning. All four distance flags then evaluate to `NA`, and `any(flag, na.rm = TRUE)` in the summary turns them into `FALSE` in every band. Those properties are counted in `n_properties` but belong to no band, so every `share_*` column is silently deflated.
+- **Evidence (verified by execution):** 62,369 of 1,450,255 rentals and 148,426 of 3,166,671 houses have all-`NA` distance. The `NA`-return behaviour of arrow's `min` was reproduced on a synthetic table.
+- **Suggested fix:** after `collect()`, map `NA` minimum distance to an explicit `beyond_radius` flag (or `Inf`) so the truncation is visible, and make the four bands plus `beyond_radius` a complete partition. Decide in the rebuild whether this diagnostic survives at all (see finding 8).
+- **Flagged by:** adversarial (empirically), correctness and maintainability (same phenomenon, different mechanism guess); mechanism pinned down and confirmed by validator execution.
+
+### 3. `[ ]` Right join in `generate_summary` pools every mapping-absent id into one fake property — active for rentals on next rerun
+
+- **Where:** `repeat_rentals.R:255-267` and `repeat_sales.R:250-262`: `rentals_dt[spill_lookup, on = "rental_id", nomatch = NA]` keeps every lookup row; lookup ids missing from the mapping survive with `repeat_id = NA` and the `by = repeat_id` aggregation pools them into a single pseudo-property.
+- **Problem:** transactions whose address key is `NA` are excluded from the exported mapping, but they are present in the spill lookup. Every such id lands in one `NA` group whose transaction count is their total number, polluting the top of the repeat-count distribution.
+- **Evidence (verified by execution):** with the current on-disk files, 1,266 rental ids (31,836 lookup rows) are absent from the rentals mapping; rerunning `generate_summary` today produces a fake property with a rental count of 31,836, versus 6 for the largest real property. Sales are dormant today (zero absent ids) purely by coincidence — nothing enforces that.
+- **Suggested fix:** drive the join from the mapping side (or use `nomatch = NULL`) and log the excluded count; add `stopifnot(!anyNA(summary_dt$repeat_id))` after the join in both twins.
+- **Flagged by:** correctness, testing, adversarial (independently); activation counts established by validator execution.
+
+### 4. `[ ]` The two scripts are one script written twice — parameterize in the rebuild
+
+- **Where:** both files, whole-script.
+- **Problem:** the twins are structurally identical (same eight functions, same control flow); only about 18% of combined lines differ, all renames, column names, and paths. Every defect in this review exists twice and every fix must be applied twice; this directory already demonstrates the fork-and-diverge failure mode (see the sibling review of 2026-07-07, finding 3, a one-twin-only copy-paste slip).
+- **Evidence:** `diff` of the two files; validator quantified 123 differing lines of ~685 combined, none behavioural.
+- **Suggested fix:** one shared pipeline function parameterized by a small config (id column, date column, price column, address columns, paths, log name), following the repo's own documented convention (`docs/solutions/design-patterns/parameterize-analysis-scripts-over-a-config-vector.md`) and the existing sourced-utils precedent (`scripts/R/utils/spill_aggregation_utils.R`, sourced by four sibling scripts). Each twin becomes a config plus a call.
+- **Flagged by:** maintainability; convention and precedent confirmed by validator.
+
+## Moderate
+
+### 5. `[ ]` `max()` on an empty repeat set produces `-Inf` repeat ids for every single-transaction property (latent edge case)
+
+- **Where:** `repeat_rentals.R:192` and `repeat_sales.R:187` (`max_repeat_id <- max(repeated_output$repeat_id)`).
+- **Problem:** if no property ever repeats (empty input, filtered subsample, schema drift upstream), `max()` of an empty vector returns `-Inf` with only a console warning that the file-based logger does not capture. Every single then gets `repeat_id = -Inf + seq_len(.N)`, the export succeeds, and the downstream `filter(n() > 1)` keeps the entire singles set as one fake property.
+- **Evidence:** `max(integer(0))` returning `-Inf` with a warning verified by execution; propagation traced mechanically.
+- **Suggested fix:** `max_repeat_id <- if (nrow(repeated_output) > 0L) max(repeated_output$repeat_id) else 0L`, plus `stopifnot(all(is.finite(all_output$repeat_id)))` before the write.
+- **Flagged by:** correctness, testing, adversarial (independently); verified by the orchestrator.
+
+### 6. `[ ]` Full-width loads and full-width intermediate copies waste roughly a gigabyte of peak memory per run
+
+- **Where:** `repeat_rentals.R:90` and `repeat_sales.R:88` (`rio::import` reads all 32 and 31 columns when only 7–8 are used); `repeat_rentals.R:186-196` and `repeat_sales.R:181-191` (`repeat_dt`/`single_dt` are full-width copies made only to derive two columns).
+- **Evidence (verified by execution):** the sales table is ~1.12 GB in memory; the two intermediate copies transiently add ~1.27 GB. Column pruning was verified against the actual parquet schemas. The one-step alternative (`dt[filter, .(id, repeat_id = .GRP), by = simple_key]`) was verified to produce the identical id-to-group partition.
+- **Suggested fix:** `arrow::read_parquet(path, col_select = ...)` plus `setDT()` at load; compute the projection inside a single data.table call in `export_repeat_ids`. Both belong in the rebuild together.
+- **Flagged by:** performance; equivalence and magnitudes confirmed by validator execution.
+
+### 7. `[ ]` Dead code and dead columns: the all-`NA` key regex can never fire, and six computed columns are never read
+
+- **Where:** regex cleanup at `repeat_rentals.R:130` and `repeat_sales.R:125`; computed columns (`*_sequence`, `lag_date`, `lag_price`, `holding_period_days`, `price_change`, `pct_change`) at `repeat_rentals.R:146-168` and `repeat_sales.R:141-163`.
+- **Problem:** the `fifelse` guard already forces the first key component to be real text, so `^(NA\|)*NA$` can only match if a cleaned field is the literal string `"NA"` — which occurs zero times in either full dataset (verified). The six per-transaction columns are exported nowhere and read by nothing (the downstream consumer selects only the id and `repeat_id`); the Palmquist script recomputes pairs itself.
+- **Suggested fix:** delete the regex lines. In the rebuild, either compute only what is exported, or deliberately export the pair metrics if a consumer is planned — decide in the grilling session.
+- **Flagged by:** maintainability (both at maximum confidence); data check by validator; consumer check by the orchestrator.
+
+### 8. `[ ]` The distance summary measures different things in the two twins and nothing consumes it
+
+- **Where:** `generate_summary`/`export_summary` in both twins; flags at `repeat_rentals.R:227-232` and `repeat_sales.R:222-227`.
+- **Problem:** the rentals lookup extends to 5 km and the sales lookup to 10 km (verified maxima 4,999.7 m and 9,998.1 m), despite both builder scripts being named "10km". So `outside_1000m` means "between 1 km and 5 km" for rentals but "between 1 km and 10 km" for sales, and the two summary parquets are not comparable. Separately, no script reads either summary output — they are human diagnostics only.
+- **Suggested fix:** decide in the rebuild whether the summary stage survives. If it does: drive it from the mapping, name the bands honestly, assert the expected lookup radius at load so a regenerated lookup fails loudly. Note the radius mismatch is already flagged as a pending P0 in `todos/012-pending-p0-review-10km-site-match-scripts.md`.
+- **Flagged by:** adversarial (empirically), maintainability; radii confirmed by validator.
+
+### 9. `[ ]` Address keys embed the literal string "NA", so inconsistent secondary-address fields split true repeat pairs
+
+- **Where:** `repeat_rentals.R:117-127` and `repeat_sales.R:115-121` (`paste(..., sep = "|")` over fields that may be `NA`).
+- **Problem:** `paste()` renders `NA` as the text `"NA"`. A house sold once with `saon` missing and once with `saon` filled gets two different keys and is missed as a repeat pair. This is systematic under-matching (Land Registry `saon` is missing for most non-flat records), and it interacts with a documented history of postcode-completeness regressions upstream.
+- **Evidence (verified by execution):** in a ~33,000-row Birmingham sample, 16 of 2,188 groups sharing postcode, primary address, and street had inconsistent `saon` missingness — the mechanism is real, magnitude modest in that sample.
+- **Suggested fix:** a methodological decision for the grilling session, not a mechanical patch: choose the key fields deliberately (for example postcode + paon + saon with explicit missing-handling), quantify both under-matching (splits) and over-merging (coarse keys) before committing, and consider cross-checking merged keys against coordinates.
+- **Flagged by:** correctness, adversarial; quantified by validator.
+
+### 10. `[ ]` No output-contract checks despite the repo having a contract-test convention
+
+- **Where:** both scripts, `export_repeat_ids` and `main`.
+- **Problem:** the exported mapping is a join key for the paper's repeat-transaction regressions, yet nothing asserts id uniqueness, row-count reconciliation against keyed input rows, finiteness of `repeat_id`, or a minimum address-key match rate. The repo already has the convention (`scripts/R/testing/test_merge_outputs_contracts.R`, `test_aggregate_spill_stats_crosswalk_contracts.R`); these two scripts predate it. A small fixture test would have caught findings 3 and 5.
+- **Suggested fix:** in the rebuild, add a contract test in `scripts/R/testing/` (uniqueness, reconciliation, finiteness, band partition) and inline `stopifnot` guards at export.
+- **Flagged by:** testing; convention existence confirmed against the repo.
+
+---
+
+## Rejected in validation
+
+- **"Replace local helpers with canonical `scripts/R/utils/` versions" (maintainability, filed P1).** Rejected as stated: `postcode_processing_utils.R::normalise_postcode` exists but is **not** behaviorally identical — it maps literal `"NA"` strings to missing, the local copies do not — so a drop-in swap could silently change match rates; `clean_basic` has no canonical counterpart; and the claimed "widespread" duplication is two scripts. The surviving kernel: in the rebuild, converge on one postcode normaliser deliberately, with the `"NA"`-handling difference decided consciously.
+
+## Residual risks and observations
+
+- Transactions with an `NA` address key (9,196 sales; unquantified for rentals) receive no `repeat_id` and are silently absent from the mapping; the downstream inner join drops them with no logged count. Log per-run attrition.
+- The two mappings use overlapping `repeat_id` ranges (both start at 1); stacking them would silently merge unrelated properties.
+- `house_id` names a transaction row, not a property — the name invites a grain misread in future code.
+- R warnings (for example from `max()` on an empty vector) are not routed to the file logger, so silent-warning failures leave no trace in `output/log`.
+- `CONFIG` paths are hardcoded with no override, and the colour log layout writes ANSI codes to file; a machine-readable run manifest (row counts, match rate, timestamps) alongside the parquet outputs would make runs auditable (agent-native review).
+- Both scripts still use the runtime `install.packages()` bootstrap that `docs/solutions/best-practices/script-setup-runtime-package-cleanup-ingestion-20260310.md` is migrating the repo away from; staged debt, worth folding into the rebuild.


### PR DESCRIPTION
Rebuilds transaction identity and the repeat-transaction mappings on content-stable foundations.

## What changed

**Content-stable transaction ids.** `house_id` and `rental_id` were positional row numbers, so an id meant nothing across a re-run or a re-ordered input. They are now xxhash64 content hashes over a documented composite, with the serialization (field order, NA token, separator, algorithm) pinned by contract tests. The cleaning scripts stage hashed sales and rental candidates; the downstream feature, panel, and analysis scripts consume the stable ids. Rationale is recorded in `docs/adr/0002-content-stable-transaction-identity.md`.

**One shared repeat pipeline.** `repeat_sales.R` and `repeat_rentals.R` were hand-maintained duplicates that had drifted. Both now sit on `scripts/R/utils/repeat_transactions_utils.R` and are thin market-specific entries. Mappings carry a manifest so successive runs can be diffed, and large-group and extreme price-ratio pairs are routed to review files rather than failing the run. The dead distance-summary stage is deleted rather than fixed — nothing consumed it.

**Same-day conflicts are excluded.** Two transactions at one address on one date contradict each other, so both sides are treated as data errors and routed to a same-day review table, with `repeat_count` counted over the survivors only. On sales this removes 102,699 rows in 50,327 conflicts: repeat share moves 0.36939131 → 0.36233545 and the largest group falls 20 → 11. Coverage is unchanged at 0.99681926 — it measures address-key completeness, which is why the manifest now reports `same_day_excluded_count` and `mapped_count` separately from `keyed_count` and `key_coverage`. Rentals contain no same-day conflicts.

**Batch-independent numeric hashing.** `format(x, scientific = FALSE, trim = TRUE)` derives one common format across a whole vector, so a value's text depended on the other rows hashed with it: `c(1200, 1300.5)` yielded `"1200.0"` where `1200` alone yielded `"1200"`. A `rental_id` was therefore not recomputable from its own row, since the locked composite includes `listing_price`. Each distinct value is now formatted on its own.

This defect was latent, never live: `listing_price` is stored as whole-valued doubles, and formatting all 3,189 distinct production values per element is identical to formatting them as a batch, so no promoted `rental_id` moves. One fractional price in a future refresh would have silently rewritten every `rental_id` in the file.

## Verification

- `scripts/R/testing/test_repeat_transactions_contracts.R` and `scripts/R/testing/test_cleaning_rebuild_contracts.R` pass, both standalone under `Rscript`.
- Locked hash fixtures `61ec4f1ca85dfdb2`, `094a16add8cb5eb0` and `89f5f526a23b82ad` are unchanged, along with the serialization preimages that produce them.
- Both markets were rebuilt end to end from the real inputs (11.2M sales rows, 5.5M rental rows) and compared field by field against the shipped datasets: mappings, manifests, and all three review tables per market are identical except `run_timestamp`.
- The ID match-rate tripwire was rerun against the current datasets: `match_rate = 1` for both markets at 11,068,790 / 5,483,171 rows.

## Notes for review

- Promotion of `*_candidate.parquet` to canonical names is still a manual `mv` with no implementation anywhere in the repo, and the repeat module lacks the `assert_candidate_output_path` guard that the cleaning module has. Worth closing separately.
- Numeric hash formatting remains dependent on `getOption("digits")`, unreachable with today's whole-valued data. An explicit `digits` would make the composite fully self-describing if fractional prices ever land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
