### PR TITLE
Flag nearby sites whose annual returns went NA then absent

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -28,6 +28,9 @@ The authoritative record of Site Group membership and reporting-year status. It 
 ### Annual Status
 The per-Site-Group-year classification that disambiguates the absence of events in the positives-only event feed: `reported_zero` (return filed, both metrics zero), `reported_positive`, `reported_na` (return filed, metrics missing), or `absent` (no return that year).
 
+### Annual-Return NA-Then-Absent Indicator
+A radius-level transaction flag equal to true when the same nearby Site Group has `reported_na` before the transaction and is later `absent` within the full annual-return horizon. The later horizon uses all years currently available in the crosswalk, so the flag may change when new monitoring years are added; it does not describe missing individual EDM event data.
+
 ### Record-Linkage Component
 A connected group of Annual-Return Sites implied by pairwise matching evidence. A component is only valid as one canonical track when it satisfies the project's site-identity invariants.
 

--- a/scripts/R/testing/test_prior_exposure_contracts.R
+++ b/scripts/R/testing/test_prior_exposure_contracts.R
@@ -555,6 +555,98 @@ assert_identical(
   "A positive year without matched events must affect its own and later cutoffs only."
 )
 
+# Annual-return sequence flags are site-specific and inspect the full available
+# crosswalk horizon, while the prefix side of the sequence remains transaction
+# specific.
+annual_return_sequence_fixture <- tidyr::expand_grid(
+  site_id = 10L + 0:3,
+  year = 2021:2024
+) |>
+  mutate(
+    water_company = "Test Water",
+    annual_status = case_when(
+      site_id == 10L & year == 2021L ~ "reported_na",
+      site_id == 10L & year >= 2022L ~ "absent",
+      site_id == 11L ~ "reported_positive",
+      site_id == 12L & year == 2021L ~ "absent",
+      site_id == 12L & year == 2022L ~ "reported_na",
+      site_id == 12L ~ "reported_positive",
+      site_id == 13L & year == 2021L ~ "reported_na",
+      site_id == 13L ~ "reported_positive",
+      TRUE ~ "reported_positive"
+    ),
+    matched_event_count = 0L
+  )
+annual_return_sequence_result <- suppressMessages(
+  derive_site_group_prefix_missing_flags(
+    annual_return_sequence_fixture,
+    base_year = 2021L,
+    cutoff_years = 2020:2023,
+    include_annual_return_sequence = TRUE
+  )
+)
+assert_true(
+  annual_return_sequence_result |>
+    filter(site_id == 10L, cutoff_year == 2021L) |>
+    pull(annual_returns_na_then_absent),
+  "A site with pre-transaction annual-return NA and a later absent year must be flagged."
+)
+assert_true(
+  !annual_return_sequence_result |>
+    filter(site_id == 10L, cutoff_year == 2022L) |>
+    pull(annual_returns_na_then_absent),
+  "A site already absent at the transaction cutoff must not be flagged."
+)
+assert_true(
+  !any(annual_return_sequence_result |>
+    filter(site_id == 11L) |>
+    pull(annual_returns_na_then_absent)),
+  "A site without annual-return NA must not be flagged."
+)
+assert_true(
+  !any(annual_return_sequence_result |>
+    filter(site_id == 12L) |>
+    pull(annual_returns_na_then_absent)),
+  "A site with absence before annual-return NA must not be flagged."
+)
+assert_true(
+  !any(annual_return_sequence_result |>
+    filter(site_id == 13L) |>
+    pull(annual_returns_na_then_absent)),
+  "A site without a later absent year must not be flagged."
+)
+sequence_same_site_metrics <- data.table(
+  transaction_id = "001",
+  site_id = c(10L, 11L),
+  distance_m = c(100, 200),
+  site_missing = FALSE,
+  annual_returns_na_then_absent = c(TRUE, FALSE),
+  spill_hrs = c(1, 2),
+  spill_count = c(1, 2)
+)
+sequence_radius_result <- prior_exposure_reduce_radius(
+  sequence_same_site_metrics, "001", c(100L, 250L)
+)
+assert_true(
+  all(sequence_radius_result$annual_returns_na_then_absent),
+  "A radius must retain a TRUE sequence flag once the same qualifying site enters it."
+)
+sequence_mixed_site_metrics <- data.table(
+  transaction_id = "001",
+  site_id = c(10L, 11L),
+  distance_m = c(100, 200),
+  site_missing = FALSE,
+  annual_returns_na_then_absent = c(FALSE, FALSE),
+  spill_hrs = c(1, 2),
+  spill_count = c(1, 2)
+)
+assert_true(
+  !any(prior_exposure_reduce_radius(
+    sequence_mixed_site_metrics, "001", c(100L, 250L)
+  )$annual_returns_na_then_absent),
+  "A radius must not combine annual-return NA and later absence from different sites."
+)
+
 for (invalid_count in list(NA_real_, -1, 1.5, "invalid")) {
   invalid_evidence_fixture <- evidence_state_fixture
   invalid_evidence_fixture$matched_event_count[1] <- invalid_count
@@ -951,7 +1043,8 @@ for (label in names(producer_specs)) {
     c(
       spec$id, price_column, "n_days_in_window", "radius", "spill_hrs",
       "n_spill_sites", "spill_count", "mean_distance", "min_distance",
-      "has_missing_site", "spill_count_daily_avg", "spill_hrs_daily_avg",
+      "has_missing_site", "annual_returns_na_then_absent",
+      "spill_count_daily_avg", "spill_hrs_daily_avg",
       "spill_count_weekly_avg", "spill_hrs_weekly_avg"
     )
   }
@@ -963,7 +1056,7 @@ for (label in names(producer_specs)) {
   } else {
     c(
       "character", "double", "integer", "double", "double", "integer",
-      "double", "double", "double", "logical", rep("double", 4L)
+      "double", "double", "double", "logical", "logical", rep("double", 4L)
     )
   }
   assert_identical(names(result), expected_columns, paste(label, "must preserve its exact schema"))
@@ -1055,7 +1148,9 @@ variant_schema_signatures <- list(
     house_id = "string", price = "int32", n_days_in_window = "int32",
     spill_hrs = "double", n_spill_sites = "int32", spill_count = "double",
     mean_distance = "double", min_distance = "double",
-    has_missing_site = "bool", spill_count_daily_avg = "double",
+    has_missing_site = "bool",
+    annual_returns_na_then_absent = "bool",
+    spill_count_daily_avg = "double",
     spill_hrs_daily_avg = "double", spill_count_weekly_avg = "double",
     spill_hrs_weekly_avg = "double", radius = "int32"
   ),
@@ -1064,6 +1159,7 @@ variant_schema_signatures <- list(
     n_days_in_window = "int32", spill_hrs = "double",
     n_spill_sites = "int32", spill_count = "double", mean_distance = "double",
     min_distance = "double", has_missing_site = "bool",
+    annual_returns_na_then_absent = "bool",
     spill_count_daily_avg = "double", spill_hrs_daily_avg = "double",
     spill_count_weekly_avg = "double", spill_hrs_weekly_avg = "double",
     radius = "int32"
@@ -1417,8 +1513,9 @@ for (label in c("sale_radius", "rental_radius")) {
   )
   assert_true(
     all(is.na(empty_rows$mean_distance)) && all(is.na(empty_rows$min_distance)) &&
-      all(!empty_rows$has_missing_site),
-    paste(label, "no-site radius rows must have missing distances and observed false missingness")
+      all(!empty_rows$has_missing_site) &&
+      all(!empty_rows$annual_returns_na_then_absent),
+    paste(label, "no-site radius rows must have missing distances and false indicators")
   )
 }
 
@@ -1510,14 +1607,16 @@ public_contract_candidate <- function(label) {
       n_days_in_window = rep(60L, 3L), spill_hrs = c(0, 60, 120),
       n_spill_sites = c(0L, 1L, 2L), spill_count = c(0, 30, 60),
       mean_distance = c(NA_real_, 100, 200), min_distance = c(NA_real_, 100, 100),
-      has_missing_site = rep(FALSE, 3L)
+      has_missing_site = rep(FALSE, 3L),
+      annual_returns_na_then_absent = rep(FALSE, 3L)
     ), common_rates),
     rental_radius = c(list(
       rental_id = rep("01leadingzero", 3L), listing_price = rep(1200, 3L),
       n_days_in_window = rep(60L, 3L), spill_hrs = c(0, 60, 120),
       n_spill_sites = c(0L, 1L, 2L), spill_count = c(0, 30, 60),
       mean_distance = c(NA_real_, 100, 200), min_distance = c(NA_real_, 100, 100),
-      has_missing_site = rep(FALSE, 3L)
+      has_missing_site = rep(FALSE, 3L),
+      annual_returns_na_then_absent = rep(FALSE, 3L)
     ), common_rates)
   )
   data.table::as.data.table(candidate)

--- a/scripts/R/utils/prior_exposure_utils.R
+++ b/scripts/R/utils/prior_exposure_utils.R
@@ -83,6 +83,7 @@ prior_exposure_public_schema <- function(market, grain) {
       mean_distance = arrow::float64(),
       min_distance = arrow::float64(),
       has_missing_site = arrow::bool(),
+      annual_returns_na_then_absent = arrow::bool(),
       spill_count_daily_avg = arrow::float64(),
       spill_hrs_daily_avg = arrow::float64(),
       spill_count_weekly_avg = arrow::float64(),
@@ -99,6 +100,7 @@ prior_exposure_public_schema <- function(market, grain) {
       mean_distance = arrow::float64(),
       min_distance = arrow::float64(),
       has_missing_site = arrow::bool(),
+      annual_returns_na_then_absent = arrow::bool(),
       spill_count_daily_avg = arrow::float64(),
       spill_hrs_daily_avg = arrow::float64(),
       spill_count_weekly_avg = arrow::float64(),
@@ -255,7 +257,8 @@ prior_exposure_load_data <- function(config, market, grain) {
     crosswalk,
     config$base_year,
     cutoff_years,
-    include_event_evidence = contract$include_event_evidence
+    include_event_evidence = contract$include_event_evidence,
+    include_annual_return_sequence = contract$grain == "radius"
   ) |>
     data.table::as.data.table()
   data.table::setkey(site_missing_dt, site_id, cutoff_year)
@@ -317,6 +320,9 @@ prior_exposure_join_events <- function(transaction_ids, data) {
   if (contract$include_event_evidence) {
     prefix_fields <- c(prefix_fields, "has_unknown_event_evidence")
   }
+  if (contract$grain == "radius") {
+    prefix_fields <- c(prefix_fields, "annual_returns_na_then_absent")
+  }
   attached <- data$site_missing_dt[, ..prefix_fields][
     transaction_sites, on = .(site_id, cutoff_year)
   ]
@@ -336,10 +342,22 @@ prior_exposure_join_events <- function(transaction_ids, data) {
     attached[, has_unknown_event_evidence := FALSE]
   }
 
-  lookup_chunk <- attached[, .(
-    transaction_id, site_id, distance_m, site_missing,
-    has_unknown_event_evidence
-  )]
+  if (contract$grain == "radius") {
+    attached[, annual_returns_na_then_absent := data.table::fifelse(
+      is.na(annual_returns_na_then_absent),
+      FALSE,
+      annual_returns_na_then_absent
+    )]
+  }
+
+  lookup_columns <- c(
+    "transaction_id", "site_id", "distance_m", "site_missing",
+    "has_unknown_event_evidence"
+  )
+  if (contract$grain == "radius") {
+    lookup_columns <- c(lookup_columns, "annual_returns_na_then_absent")
+  }
+  lookup_chunk <- attached[, ..lookup_columns]
   public_lookup <- data.table::copy(lookup_chunk)
   data.table::setnames(public_lookup, "transaction_id", contract$id)
 
@@ -351,9 +369,14 @@ prior_exposure_join_events <- function(transaction_ids, data) {
   # data.table's grouped floating reducer is sensitive to the joined table's
   # otherwise-unused columns, so project the exact established public shape.
   event_sources <- data.table::copy(attached)
-  event_sources[, c(
-    "cutoff_year", "n_days_in_window", "has_unknown_event_evidence"
-  ) := NULL]
+  event_metadata_fields <- intersect(
+    c(
+      "cutoff_year", "n_days_in_window", "has_unknown_event_evidence",
+      "annual_returns_na_then_absent"
+    ),
+    names(event_sources)
+  )
+  event_sources[, (event_metadata_fields) := NULL]
   data.table::setnames(
     event_sources,
     c("transaction_id", "transaction_value", "transaction_endpoint"),
@@ -388,17 +411,36 @@ prior_exposure_join_events <- function(transaction_ids, data) {
 prior_exposure_transaction_site_metrics <- function(joined, contract) {
   lookup <- data.table::copy(joined$internal_lookup)
   if (nrow(lookup) == 0L) return(NULL)
+  has_annual_return_sequence <-
+    "annual_returns_na_then_absent" %in% names(lookup)
   site_lookup <- if (contract$include_event_evidence) {
-    lookup[, .(
-      distance_m = min(distance_m),
-      site_missing = any(site_missing),
-      has_unknown_event_evidence = any(has_unknown_event_evidence)
-    ), by = .(transaction_id, site_id)]
+    if (has_annual_return_sequence) {
+      lookup[, .(
+        distance_m = min(distance_m),
+        site_missing = any(site_missing),
+        has_unknown_event_evidence = any(has_unknown_event_evidence),
+        annual_returns_na_then_absent = any(annual_returns_na_then_absent)
+      ), by = .(transaction_id, site_id)]
+    } else {
+      lookup[, .(
+        distance_m = min(distance_m),
+        site_missing = any(site_missing),
+        has_unknown_event_evidence = any(has_unknown_event_evidence)
+      ), by = .(transaction_id, site_id)]
+    }
   } else {
-    lookup[, .(
-      distance_m = min(distance_m),
-      site_missing = any(site_missing)
-    ), by = .(transaction_id, site_id)]
+    if (has_annual_return_sequence) {
+      lookup[, .(
+        distance_m = min(distance_m),
+        site_missing = any(site_missing),
+        annual_returns_na_then_absent = any(annual_returns_na_then_absent)
+      ), by = .(transaction_id, site_id)]
+    } else {
+      lookup[, .(
+        distance_m = min(distance_m),
+        site_missing = any(site_missing)
+      ), by = .(transaction_id, site_id)]
+    }
   }
 
   events <- joined$events_dt
@@ -446,9 +488,13 @@ prior_exposure_reduce_radius <- function(site_metrics, transaction_ids, radii) {
     grid[, `:=`(
       spill_hrs = 0, n_spill_sites = 0L, spill_count = 0,
       mean_distance = NA_real_, min_distance = NA_real_,
-      has_missing_site = FALSE
+      has_missing_site = FALSE,
+      annual_returns_na_then_absent = FALSE
     )]
     return(grid)
+  }
+  if (!"annual_returns_na_then_absent" %in% names(site_metrics)) {
+    site_metrics[, annual_returns_na_then_absent := FALSE]
   }
   # Preserve the historical accumulation order exactly: collapse distance ties,
   # sort by distance, then take cumulative sums for rolling radius thresholds.
@@ -460,7 +506,8 @@ prior_exposure_reduce_radius <- function(site_metrics, transaction_ids, radii) {
     spill_count = prior_exposure_stable_sum(spill_count),
     n_spill_sites = .N,
     distance_sum = prior_exposure_stable_sum(distance_m),
-    missing_sites = prior_exposure_stable_sum(site_missing)
+    missing_sites = prior_exposure_stable_sum(site_missing),
+    annual_returns_na_then_absent = any(annual_returns_na_then_absent)
   ), by = .(transaction_id, distance_m)]
   data.table::setorder(site_agg, transaction_id, distance_m)
   site_agg[, `:=`(
@@ -469,6 +516,9 @@ prior_exposure_reduce_radius <- function(site_metrics, transaction_ids, radii) {
     cum_distance_sum = prior_exposure_stable_cumsum(distance_sum),
     n_spill_sites = prior_exposure_stable_cumsum(n_spill_sites),
     cum_missing_sites = prior_exposure_stable_cumsum(missing_sites),
+    cum_annual_returns_na_then_absent = dplyr::cumany(
+      annual_returns_na_then_absent
+    ),
     min_distance = distance_m[1L]
   ), by = transaction_id]
   data.table::setkey(site_agg, transaction_id, distance_m)
@@ -500,6 +550,11 @@ prior_exposure_reduce_radius <- function(site_metrics, transaction_ids, radii) {
     ),
     has_missing_site = data.table::fifelse(
       is.na(cum_missing_sites), FALSE, cum_missing_sites > 0
+    ),
+    annual_returns_na_then_absent = data.table::fifelse(
+      is.na(cum_annual_returns_na_then_absent),
+      FALSE,
+      cum_annual_returns_na_then_absent
     )
   )]
   metrics[has_missing_site == TRUE, `:=`(
@@ -507,10 +562,12 @@ prior_exposure_reduce_radius <- function(site_metrics, transaction_ids, radii) {
   )]
   metrics <- metrics[, .(
     transaction_id, radius, spill_hrs, n_spill_sites, spill_count,
-    mean_distance, min_distance, has_missing_site
+    mean_distance, min_distance, has_missing_site,
+    annual_returns_na_then_absent
   )]
   result <- metrics[grid, on = .(transaction_id, radius)]
   result[is.na(has_missing_site), has_missing_site := FALSE]
+  result[is.na(annual_returns_na_then_absent), annual_returns_na_then_absent := FALSE]
   result[!has_missing_site & is.na(spill_hrs), spill_hrs := 0]
   result[!has_missing_site & is.na(spill_count), spill_count := 0]
   result[is.na(n_spill_sites), n_spill_sites := 0L]
@@ -545,7 +602,8 @@ prior_exposure_project_public <- function(result, contract) {
     columns <- c(
       contract$id, contract$value, "n_days_in_window", "radius", "spill_hrs",
       "n_spill_sites", "spill_count", "mean_distance", "min_distance",
-      "has_missing_site", "spill_count_daily_avg", "spill_hrs_daily_avg",
+      "has_missing_site", "annual_returns_na_then_absent",
+      "spill_count_daily_avg", "spill_hrs_daily_avg",
       "spill_count_weekly_avg", "spill_hrs_weekly_avg"
     )
   }

--- a/scripts/R/utils/site_group_utils.R
+++ b/scripts/R/utils/site_group_utils.R
@@ -139,11 +139,16 @@ read_site_group_missing_flags <- function(file_path, years) {
 #'   include `base_year - 1L` for the explicit empty prefix.
 #' @param include_event_evidence Whether to include cumulative unknown-event
 #'   evidence alongside the historical prefix-missingness contract.
+#' @param include_annual_return_sequence Whether to include the site-level
+#'   `annual_returns_na_then_absent` sequence flag. The full available
+#'   crosswalk horizon is used for the later `absent` test.
 #' @return A tibble unique on `site_id` and `cutoff_year`, with logical
-#'   `site_missing` and, when requested, `has_unknown_event_evidence`.
+#'   `site_missing` and, when requested, `has_unknown_event_evidence` and
+#'   `annual_returns_na_then_absent`.
 derive_site_group_prefix_missing_flags <- function(crosswalk, base_year,
                                                    cutoff_years,
-                                                   include_event_evidence = FALSE) {
+                                                   include_event_evidence = FALSE,
+                                                   include_annual_return_sequence = FALSE) {
   required_columns <- c(
     "site_id", "year", "water_company", "annual_status",
     "matched_event_count"
@@ -244,10 +249,21 @@ derive_site_group_prefix_missing_flags <- function(crosswalk, base_year,
   }
 
   non_empty_cutoffs <- cutoff_years[cutoff_years >= base_year]
-  required_years <- if (length(non_empty_cutoffs) == 0L) {
+  full_window_end_year <- if (isTRUE(include_annual_return_sequence)) {
+    max(crosswalk$year)
+  } else {
+    -Inf
+  }
+  required_end_year <- max(
+    c(
+      full_window_end_year,
+      if (length(non_empty_cutoffs) == 0L) -Inf else max(non_empty_cutoffs)
+    )
+  )
+  required_years <- if (!is.finite(required_end_year)) {
     integer()
   } else {
-    seq.int(base_year, max(non_empty_cutoffs))
+    seq.int(base_year, required_end_year)
   }
   unsupported_years <- setdiff(required_years, sort(unique(crosswalk$year)))
   if (length(unsupported_years) > 0L) {
@@ -268,7 +284,8 @@ derive_site_group_prefix_missing_flags <- function(crosswalk, base_year,
       site_id = integer(),
       cutoff_year = integer(),
       site_missing = logical(),
-      has_unknown_event_evidence = logical()
+      has_unknown_event_evidence = logical(),
+      has_reported_na_prefix = logical()
     )
   } else {
     tidyr::expand_grid(
@@ -294,14 +311,43 @@ derive_site_group_prefix_missing_flags <- function(crosswalk, base_year,
           (.data$annual_status == "reported_positive" &
             .data$matched_event_count == 0L),
         site_missing = dplyr::cumany(.data$annual_status == "absent"),
+        has_reported_na_prefix = dplyr::cumany(
+          .data$annual_status == "reported_na"
+        ),
         has_unknown_event_evidence = dplyr::cumany(.data$event_evidence_unknown),
         .by = "site_id"
       ) |>
       dplyr::filter(.data$cutoff_year %in% cutoff_years) |>
       dplyr::select(
         "site_id", "cutoff_year", "site_missing",
-        "has_unknown_event_evidence"
+        "has_unknown_event_evidence", "has_reported_na_prefix"
       )
+  }
+
+  if (isTRUE(include_annual_return_sequence) && nrow(non_empty_prefixes) > 0L) {
+    absent_rows <- observed |>
+      dplyr::filter(.data$annual_status == "absent")
+    last_absent_year <- if (nrow(absent_rows) == 0L) {
+      tibble::tibble(site_id = integer(), last_absent_year = integer())
+    } else {
+      absent_rows |>
+        dplyr::summarise(
+          last_absent_year = max(.data$year),
+          .by = "site_id"
+        )
+    }
+    non_empty_prefixes <- non_empty_prefixes |>
+      dplyr::left_join(last_absent_year, by = "site_id") |>
+      dplyr::mutate(
+        annual_returns_na_then_absent =
+          .data$has_reported_na_prefix &
+          !.data$site_missing &
+          !is.na(.data$last_absent_year) &
+          .data$last_absent_year > .data$cutoff_year
+      ) |>
+      dplyr::select(-"last_absent_year")
+  } else {
+    non_empty_prefixes$annual_returns_na_then_absent <- FALSE
   }
 
   empty_prefixes <- if ((base_year - 1L) %in% cutoff_years) {
@@ -309,24 +355,31 @@ derive_site_group_prefix_missing_flags <- function(crosswalk, base_year,
       site_id = all_site_ids,
       cutoff_year = base_year - 1L,
       site_missing = FALSE,
-      has_unknown_event_evidence = FALSE
+      has_unknown_event_evidence = FALSE,
+      has_reported_na_prefix = FALSE,
+      annual_returns_na_then_absent = FALSE
     )
   } else {
     tibble::tibble(
       site_id = integer(),
       cutoff_year = integer(),
       site_missing = logical(),
-      has_unknown_event_evidence = logical()
+      has_unknown_event_evidence = logical(),
+      has_reported_na_prefix = logical(),
+      annual_returns_na_then_absent = logical()
     )
   }
 
   prefixes <- dplyr::bind_rows(empty_prefixes, non_empty_prefixes) |>
     dplyr::arrange(.data$site_id, .data$cutoff_year)
-  if (!isTRUE(include_event_evidence)) {
-    prefixes <- dplyr::select(
-      prefixes, "site_id", "cutoff_year", "site_missing"
-    )
+  output_columns <- c("site_id", "cutoff_year", "site_missing")
+  if (isTRUE(include_event_evidence)) {
+    output_columns <- c(output_columns, "has_unknown_event_evidence")
   }
+  if (isTRUE(include_annual_return_sequence)) {
+    output_columns <- c(output_columns, "annual_returns_na_then_absent")
+  }
+  prefixes <- dplyr::select(prefixes, dplyr::all_of(output_columns))
   prefixes
 }
 


### PR DESCRIPTION
Adds a radius-level indicator for nearby Site Groups whose annual returns went `reported_na` before a transaction and later lapsed to `absent`.

## Why

The event feed carries positives only, so it cannot distinguish a site that reported nothing from a site that stopped reporting. A transaction near a site whose annual returns lapse therefore looks identical to one near a genuinely quiet site. `has_missing_site` already covers sites that are absent *by* the transaction date; this covers the case where the lapse comes later and casts doubt on the pre-transaction record.

## What it means

`annual_returns_na_then_absent` is true when a Site Group within the radius filed `reported_na` before the transaction cutoff and is `absent` in some later year.

Two design points worth review attention:

- **The later-absent test uses the full annual-return horizon available in the crosswalk**, not the transaction's cutoff window — the question is whether reporting ultimately lapsed, not whether it had lapsed by the transaction date. This makes the flag a function of the data currently available: **adding monitoring years can flip it**. `CONCEPTS.md` records that explicitly, along with the fact that it describes annual-return coverage rather than missing individual EDM event data.
- Sites already absent at the cutoff are excluded (`has_missing_site` covers them), as are sites whose absence precedes the NA.

Radius grain only. The flag is `any()` across sites within the radius and accumulates monotonically outward.

## Changes

- `scripts/R/utils/site_group_utils.R` — `derive_site_group_prefix_missing_flags()` gains `include_annual_return_sequence`, which widens the required-year window to the full crosswalk horizon and derives the flag from the NA prefix plus the last absent year.
- `scripts/R/utils/prior_exposure_utils.R` — threads the flag through load → join → site metrics → radius reduction, and adds it to the radius public Arrow schema.
- `scripts/R/testing/test_prior_exposure_contracts.R` — five cases: flagged, already-absent at cutoff, no NA, absence before NA, no later absent year; plus radius propagation.
- `CONCEPTS.md` — defines the concept.

## Note on existing artifacts

The radius public schema gains a column, so prior-to-sale and prior-to-rental artifacts built before this predate it. Regenerating them is not in this PR; the producers are `house_spill_prior_to_sale.R`, `rental_spill_prior_to_rental.R`, `cross_section_prior_to_sale.R`, and `cross_section_prior_to_rental.R`.

## Verification

`Rscript scripts/R/testing/test_prior_exposure_contracts.R` passes, both before the commit and on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
