### PR TITLE
Publish repeat mappings automatically instead of staging them for a manual move

### DIFF
--- a/docs/pipeline_documentation.md
+++ b/docs/pipeline_documentation.md
@@ -90,7 +90,12 @@ The main analysis scripts live separately in `scripts/R/09_analysis/`, while val
   from same-day exclusion (`same_day_excluded_count`, `mapped_count`), because
   the two measure different data-quality failures and carry different floors.
   Persisted `repeat_count` is defined over the full long-run input; consumers
-  that filter the date window must regroup after filtering.
+  that filter the date window must regroup after filtering. Both entries publish
+  their own outputs: each run stages `*_candidate.parquet` files and, once its
+  checks pass, promotes all four onto the canonical paths, so a successful run
+  leaves the live datasets current with no manual move. A failed run promotes
+  nothing and leaves the previous generation in place, which is also the only
+  copy of it — publication keeps no backup.
 
 ## Analysis Scripts
 

--- a/scripts/R/06_analysis_datasets/repeat_rentals.R
+++ b/scripts/R/06_analysis_datasets/repeat_rentals.R
@@ -13,13 +13,10 @@
 #   - data/processed/zoopla/zoopla_rentals_long_run.parquet (2014–2023)
 #
 # Outputs:
-#   - data/processed/repeated_transactions/repeated_rentals_candidate.parquet
-#   - data/processed/repeated_transactions/
-#       repeated_rentals_large_groups_candidate.parquet
-#   - data/processed/repeated_transactions/
-#       repeated_rentals_price_ratios_candidate.parquet
-#   - data/processed/repeated_transactions/
-#       repeated_rentals_same_day_candidate.parquet
+#   - data/processed/repeated_transactions/repeated_rentals.parquet
+#   - data/processed/repeated_transactions/repeated_rentals_large_groups.parquet
+#   - data/processed/repeated_transactions/repeated_rentals_price_ratios.parquet
+#   - data/processed/repeated_transactions/repeated_rentals_same_day.parquet
 #   - output/log/repeat_rentals.log
 #
 # Notes:
@@ -27,7 +24,9 @@
 #   - Window-restricted consumers must regroup after filtering.
 #   - Rentals sharing an address and a date are data errors: every conflicting
 #     row is excluded from the mapping and routed to the same-day review.
-#   - Candidate outputs are promoted only after validation succeeds.
+#   - Outputs are staged as `*_candidate.parquet` and promoted onto the paths
+#     above only once the run's checks pass; a failed run leaves the previous
+#     generation in place. Publication replaces it without keeping a backup.
 # ==============================================================================
 
 if (!requireNamespace("here", quietly = TRUE)) {
@@ -90,6 +89,7 @@ repeat_rentals_config <- function(output_dir = here::here(
     price_ratio_review_path = file.path(output_dir, "repeated_rentals_price_ratios_candidate.parquet"),
     same_day_review_path = file.path(output_dir, "repeated_rentals_same_day_candidate.parquet"),
     market = "rentals",
+    publish = TRUE,
     year_min = 2014L,
     year_max = 2023L,
     # Observed 2026-08-15 baselines: coverage 1.00000000, repeat share 0.74848970.

--- a/scripts/R/06_analysis_datasets/repeat_sales.R
+++ b/scripts/R/06_analysis_datasets/repeat_sales.R
@@ -13,13 +13,10 @@
 #   - data/processed/house_price_long_run.parquet (2014–2024)
 #
 # Outputs:
-#   - data/processed/repeated_transactions/repeated_sales_candidate.parquet
-#   - data/processed/repeated_transactions/
-#       repeated_sales_large_groups_candidate.parquet
-#   - data/processed/repeated_transactions/
-#       repeated_sales_price_ratios_candidate.parquet
-#   - data/processed/repeated_transactions/
-#       repeated_sales_same_day_candidate.parquet
+#   - data/processed/repeated_transactions/repeated_sales.parquet
+#   - data/processed/repeated_transactions/repeated_sales_large_groups.parquet
+#   - data/processed/repeated_transactions/repeated_sales_price_ratios.parquet
+#   - data/processed/repeated_transactions/repeated_sales_same_day.parquet
 #   - output/log/repeat_sales.log
 #
 # Notes:
@@ -27,7 +24,9 @@
 #   - Window-restricted consumers must regroup after filtering.
 #   - Sales sharing an address and a date are data errors: every conflicting row
 #     is excluded from the mapping and routed to the same-day review.
-#   - Candidate outputs are promoted only after validation succeeds.
+#   - Outputs are staged as `*_candidate.parquet` and promoted onto the paths
+#     above only once the run's checks pass; a failed run leaves the previous
+#     generation in place. Publication replaces it without keeping a backup.
 # ==============================================================================
 
 if (!requireNamespace("here", quietly = TRUE)) {
@@ -86,6 +85,7 @@ repeat_sales_config <- function(output_dir = here::here(
     price_ratio_review_path = file.path(output_dir, "repeated_sales_price_ratios_candidate.parquet"),
     same_day_review_path = file.path(output_dir, "repeated_sales_same_day_candidate.parquet"),
     market = "sales",
+    publish = TRUE,
     year_min = 2014L,
     year_max = 2024L,
     # Observed 2026-08-15 baselines: coverage 0.99681926, repeat share 0.36233545.

--- a/scripts/R/testing/test_repeat_transactions_contracts.R
+++ b/scripts/R/testing/test_repeat_transactions_contracts.R
@@ -422,6 +422,116 @@ assert_true(
   "New metrics must appear in the delta even when the previous manifest lacks them."
 )
 
+# Publication: a successful run promotes its staged candidates onto the canonical
+# paths, so the live datasets never depend on a manual move.
+publish_config <- make_config("publish")
+publish_config$output_path <- file.path(test_dir, "publish_mapping_candidate.parquet")
+publish_config$large_group_review_path <- file.path(test_dir, "publish_large_candidate.parquet")
+publish_config$price_ratio_review_path <- file.path(test_dir, "publish_ratios_candidate.parquet")
+publish_config$same_day_review_path <- file.path(test_dir, "publish_same_day_candidate.parquet")
+publish_config$previous_manifest_path <- file.path(test_dir, "publish_mapping.parquet")
+publish_config$publish <- TRUE
+staged_paths <- c(
+  publish_config$output_path, publish_config$large_group_review_path,
+  publish_config$price_ratio_review_path, publish_config$same_day_review_path
+)
+canonical_paths <- sub("_candidate\\.parquet$", ".parquet", staged_paths)
+publish_logs <- character()
+run_repeat_transactions(
+  publish_config,
+  data = fixture,
+  log_fn = function(level, message) publish_logs <<- c(publish_logs, paste(level, message))
+)
+assert_true(
+  all(file.exists(canonical_paths)),
+  "A published run must leave every canonical output in place."
+)
+assert_true(
+  !any(file.exists(staged_paths)),
+  "A published run must consume its staged candidates rather than leaving them behind."
+)
+assert_true(
+  any(grepl("promot", publish_logs, ignore.case = TRUE)),
+  "Publication must be logged so a run records that it replaced the canonical outputs."
+)
+published <- arrow::read_parquet(canonical_paths[[1]], as_data_frame = FALSE)
+assert_identical(
+  names(published), c("house_id", "repeat_id", "repeat_count"),
+  "The promoted mapping must carry the declared public schema."
+)
+assert_identical(
+  published$metadata$mapped_count, "3",
+  "The promoted mapping must carry its run's manifest."
+)
+
+# Republishing over an existing canonical generation is the normal case.
+run_repeat_transactions(publish_config, data = fixture)
+assert_true(
+  all(file.exists(canonical_paths)) && !any(file.exists(staged_paths)),
+  "A second published run must replace the previous canonical generation."
+)
+
+# Publication is opt-in: without it, the canonical paths are untouched.
+unpublished_config <- make_config("unpublished")
+unpublished_config$output_path <- file.path(test_dir, "unpublished_mapping_candidate.parquet")
+unpublished_canonical <- file.path(test_dir, "unpublished_mapping.parquet")
+run_repeat_transactions(unpublished_config, data = fixture)
+assert_true(
+  file.exists(unpublished_config$output_path),
+  "Without publication the staged candidate must remain for inspection."
+)
+assert_true(
+  !file.exists(unpublished_canonical),
+  "Without publication no canonical output may be written."
+)
+
+# A publishing config must name candidate paths, so a mistyped path cannot
+# designate an arbitrary file as a promotion target.
+non_candidate_config <- make_config("non-candidate")
+non_candidate_config$publish <- TRUE
+assert_error_matching(
+  run_repeat_transactions(non_candidate_config, data = fixture),
+  "candidate",
+  "Publishing a non-candidate output path must abort."
+)
+assert_true(
+  !file.exists(non_candidate_config$output_path),
+  "A rejected publication target must abort before writing any output."
+)
+
+# A run that fails its own checks must not touch the canonical datasets.
+failing_config <- publish_config
+failing_config$key_coverage_floor <- 0.9
+assert_error_matching(
+  run_repeat_transactions(failing_config, data = missing_fixture),
+  "coverage",
+  "A failed check battery must abort before publication."
+)
+assert_identical(
+  arrow::read_parquet(canonical_paths[[1]], as_data_frame = FALSE)$metadata$input_row_count,
+  "3",
+  "A failed run must leave the previous canonical generation intact."
+)
+
+# Promotion re-reads what it wrote: a mapping that contradicts its manifest fails.
+corrupt_promotion_dir <- file.path(test_dir, "corrupt-promotion")
+dir.create(corrupt_promotion_dir, recursive = TRUE)
+corrupt_staged <- file.path(corrupt_promotion_dir, "corrupt_mapping_candidate.parquet")
+arrow::write_parquet(
+  data.frame(
+    house_id = "01abc", repeat_id = strrep("a", 16L), repeat_count = 1L
+  ),
+  corrupt_staged
+)
+assert_error_matching(
+  promote_repeat_outputs(
+    list(output_path = corrupt_staged),
+    manifest = list(mapped_count = "99")
+  ),
+  "row count|manifest",
+  "A promoted mapping whose row count contradicts its manifest must abort."
+)
+
 corrupt_manifest_path <- file.path(test_dir, "corrupt-previous.parquet")
 writeBin(charToRaw("not parquet"), corrupt_manifest_path)
 assert_error_matching(
@@ -444,10 +554,18 @@ assert_identical(
   c(0.99, 0.35),
   "Sales production floors must remain locked below the accepted baseline."
 )
+assert_true(
+  isTRUE(sales_entry_config$publish),
+  "The repeat-sales entry must publish its outputs rather than stage them for a manual move."
+)
 sales_env$main(sales_entry_config, data = fixture)
 assert_true(
-  file.exists(sales_entry_config$output_path),
-  "The repeat-sales entry script must run a fixture end-to-end."
+  file.exists(repeat_canonical_path(sales_entry_config$output_path)),
+  "The repeat-sales entry script must run a fixture end-to-end onto its canonical output."
+)
+assert_true(
+  !file.exists(sales_entry_config$output_path),
+  "The repeat-sales entry script must leave no staged candidate behind."
 )
 
 rentals_fixture <- data.table(
@@ -475,10 +593,18 @@ assert_identical(
   c(0.99, 0.70),
   "Rental production floors must remain locked below the accepted baseline."
 )
+assert_true(
+  isTRUE(rentals_entry_config$publish),
+  "The repeat-rentals entry must publish its outputs rather than stage them for a manual move."
+)
 rentals_env$main(rentals_entry_config, data = rentals_fixture)
 assert_true(
-  file.exists(rentals_entry_config$output_path),
-  "The repeat-rentals entry script must run a fixture end-to-end."
+  file.exists(repeat_canonical_path(rentals_entry_config$output_path)),
+  "The repeat-rentals entry script must run a fixture end-to-end onto its canonical output."
+)
+assert_true(
+  !file.exists(rentals_entry_config$output_path),
+  "The repeat-rentals entry script must leave no staged candidate behind."
 )
 
 cat("Repeat transaction contract tests passed.\n")

--- a/scripts/R/utils/repeat_transactions_utils.R
+++ b/scripts/R/utils/repeat_transactions_utils.R
@@ -41,6 +41,11 @@ validate_repeat_config <- function(config) {
       config$repeat_share_floor < 0 || config$repeat_share_floor > 1) {
     stop("Coverage and repeat-share floors must lie in [0, 1].", call. = FALSE)
   }
+  # Reject an unpublishable path before the run does any work, rather than after
+  # the mappings have been built.
+  if (isTRUE(config$publish)) {
+    invisible(lapply(repeat_staged_output_paths(config), repeat_canonical_path))
+  }
   invisible(config)
 }
 
@@ -392,7 +397,7 @@ write_arrow_table_atomic <- function(table, path) {
   on.exit(unlink(tmp), add = TRUE)
   arrow::write_parquet(table, tmp)
   if (!file.rename(tmp, path)) {
-    stop("Failed to promote staged parquet to ", path, ".", call. = FALSE)
+    stop("Failed to write staged parquet to ", path, ".", call. = FALSE)
   }
   invisible(path)
 }
@@ -408,6 +413,98 @@ write_repeat_outputs <- function(result, config, manifest) {
   write_arrow_table_atomic(as.data.frame(result$price_ratio_issues), config$price_ratio_review_path)
   write_arrow_table_atomic(as.data.frame(result$same_day_conflicts), config$same_day_review_path)
   invisible(config$output_path)
+}
+
+#' The four staged outputs a run writes, in publication order
+repeat_staged_output_paths <- function(config) {
+  c(
+    config$output_path, config$large_group_review_path,
+    config$price_ratio_review_path, config$same_day_review_path
+  )
+}
+
+#' Canonical destination for a staged candidate path
+#'
+#' Fails closed on any path that is not a candidate, so a mistyped config cannot
+#' nominate an arbitrary file as a publication target.
+repeat_canonical_path <- function(path) {
+  canonical <- sub("_candidate\\.parquet$", ".parquet", path)
+  if (identical(canonical, path)) {
+    stop(
+      "Repeat output path is not a candidate path and cannot be published: ",
+      path,
+      call. = FALSE
+    )
+  }
+  canonical
+}
+
+#' Re-read a staged mapping and check it against the manifest it will carry
+#'
+#' Renaming cannot corrupt a file, so this runs before the swap rather than
+#' after it: a staged mapping that disagrees with its own run aborts while the
+#' canonical generation is still intact.
+assert_promotable_mapping <- function(path, manifest) {
+  table <- tryCatch(
+    arrow::read_parquet(path, as_data_frame = FALSE),
+    error = function(e) {
+      stop(
+        "Staged mapping is unreadable and cannot be published: ", path, ". ",
+        conditionMessage(e),
+        call. = FALSE
+      )
+    }
+  )
+  expected <- manifest$mapped_count
+  if (!is.null(expected) &&
+      !identical(as.character(table$num_rows), as.character(expected))) {
+    stop(
+      "Staged mapping row count ", table$num_rows,
+      " contradicts its manifest mapped_count ", expected, ".",
+      call. = FALSE
+    )
+  }
+  invisible(path)
+}
+
+#' Replace the canonical outputs with this run's staged candidates
+#'
+#' Every output is written before anything is promoted, so publication is four
+#' renames executed back to back. A failure partway still leaves some outputs at
+#' the new generation and some at the old, but the window is milliseconds rather
+#' than the minutes it takes to write the mappings; the filesystem offers no
+#' transaction that would close it entirely.
+promote_repeat_outputs <- function(config, manifest, log_fn = NULL) {
+  staged <- repeat_staged_output_paths(config)
+  targets <- vapply(staged, repeat_canonical_path, character(1), USE.NAMES = FALSE)
+
+  absent <- staged[!file.exists(staged)]
+  if (length(absent) > 0L) {
+    stop(
+      "Cannot publish; staged output(s) missing: ",
+      paste(absent, collapse = ", "),
+      call. = FALSE
+    )
+  }
+  assert_promotable_mapping(staged[[1L]], manifest)
+
+  for (index in seq_along(staged)) {
+    if (!file.rename(staged[[index]], targets[[index]])) {
+      stop(
+        "Failed to publish ", staged[[index]], " to ", targets[[index]], ".",
+        call. = FALSE
+      )
+    }
+  }
+  emit_repeat_log(
+    "INFO",
+    sprintf(
+      "Promoted %d staged output(s) to canonical paths: %s",
+      length(targets), paste(basename(targets), collapse = ", ")
+    ),
+    log_fn
+  )
+  invisible(targets)
 }
 
 load_repeat_input <- function(config) {
@@ -458,6 +555,9 @@ run_repeat_transactions <- function(config, data = NULL, log_fn = NULL) {
     log_fn
   )
   write_repeat_outputs(result, config, manifest)
+  if (isTRUE(config$publish)) {
+    promote_repeat_outputs(config, manifest, log_fn)
+  }
   result$manifest <- manifest
   invisible(result)
 }


### PR DESCRIPTION
Makes a successful repeat-mapping run leave the live datasets updated, instead of leaving candidates for a manual `mv`.

## Why

`repeat_sales.R` and `repeat_rentals.R` wrote only `*_candidate.parquet`. Turning a candidate into the dataset everything reads was a manual step that existed **nowhere in code** — the header claim that "candidate outputs are promoted only after validation succeeds" described an intended ordering, not an implementation. In practice that meant nothing recorded that a promotion had happened, nothing stopped an unvalidated candidate being promoted, and the canonical files could silently lag the code that produced them.

## What changed

A run now publishes its own outputs, gated on `config$publish` (set on both production entries).

**Staging is kept deliberately.** `data/` is a Dropbox-synced symlink shared across branches, and writing ~570 MB directly over production while a run is still deciding whether it succeeded is exactly the risk staging exists to avoid. So all four outputs are written as candidates first; only once every write has succeeded are the four renamed onto the canonical paths.

**`repeat_canonical_path()` fails closed** on any output path lacking the `_candidate` suffix. It runs during config validation, so an unpublishable path aborts before the run does any work rather than after the mappings are built. This is the guard the repeat module lacked entirely — the cleaning module has had its equivalent in `assert_candidate_output_path`.

**Publication re-reads what it is about to publish**, rejecting a staged mapping whose row count contradicts the manifest it carries. This runs *before* the swap rather than after: renaming cannot corrupt content, so failing early leaves the previous generation intact. (The repo's `dataset_publication_utils.R` validates on both sides, but it is directory-only — twelve `dir.exists()` calls — so reusing it would mean changing a shared utility six other callers depend on, promoting one path per call with no cross-file rollback, and writing a validator the repeat pipeline does not have. Its `.prev` is transient too, deleted on success, so it is not the backup it appears to be.)

## Two limits, stated rather than papered over

- **No backup.** Publication replaces the previous generation and keeps no copy. The outputs are deterministic — a rerun last night reproduced them byte-for-byte — so a good rerun restores them, but a bad input destroys the prior mapping.
- **Four renames, not one transaction.** A failure partway leaves some outputs at the new generation and some at the old. The window is milliseconds, since renames are metadata operations run back-to-back after all writing is done, but it is not zero and the filesystem offers no way to close it.

## Tests

New contract cases: a published run leaves all four canonical outputs and no candidates; republishing over an existing generation works; without `publish` the old behaviour is exactly preserved; a non-candidate output path aborts before writing anything; a failed check battery leaves the canonical generation intact; and a staged mapping contradicting its manifest aborts.

The two entry-script tests previously asserted the candidate file survives the run — that contract genuinely changed, so they now assert the canonical output exists and no candidate is left behind.

`Rscript scripts/R/testing/test_repeat_transactions_contracts.R` and `test_cleaning_rebuild_contracts.R` both pass. No production rerun: the two scripts take ~26 minutes together and runs may be in flight.

## Follow-up, not in this PR

Any run started before this lands still writes candidates that need one final manual promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
